### PR TITLE
Add CNN model tuning experiments and finalize best model script

### DIFF
--- a/notebooks/experiment_optimization.ipynb
+++ b/notebooks/experiment_optimization.ipynb
@@ -1,0 +1,457 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2cc91a16",
+   "metadata": {},
+   "source": [
+    "# Import Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9daae549",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from keras.callbacks import EarlyStopping\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b62e209",
+   "metadata": {},
+   "source": [
+    "# Configuring project paths and importing core modules"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ef5364c",
+   "metadata": {},
+   "source": [
+    "## "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a76705cc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\admin\\Desktop\n",
+      "c:\\Users\\admin\\Desktop\\data\n",
+      "c:\\Users\\admin\\Desktop\\data\\dl_features\n"
+     ]
+    }
+   ],
+   "source": [
+    "BASE_DIR = Path.cwd().parents[1]\n",
+    "DATA_DIR = BASE_DIR / \"data\"\n",
+    "FEATURES_DIR = DATA_DIR / \"dl_features\"\n",
+    "print(BASE_DIR)\n",
+    "print(DATA_DIR)\n",
+    "print(FEATURES_DIR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70a7b169",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "sys.path.append(str(Path.cwd().parent)) \n",
+    "\n",
+    "from src.models.cnn_baseline import load_features, build_cnn_model, evaluate_model\n",
+    "import src.models.cnn_baseline as cnn_utils\n",
+    "from pathlib import Path\n",
+    "\n",
+    "cnn_utils.FEATURES_DIR = Path(r\"C:\\Users\\admin\\Desktop\\nlp-fake-news-detector-transformers\\data\\dl_features\")\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d759648",
+   "metadata": {},
+   "source": [
+    "# Hyperparameter Tuning & Experiments\n",
+    "To achieve the best performance, we conduct several experiments varying the following:\n",
+    "* **Optimizers:** Adam vs. RMSprop.\n",
+    "* **Dropout Rates:** 0.5 vs. 0.7 (to control overfitting).\n",
+    "* **Batch Sizes:** 32 vs. 64.\n",
+    "\n",
+    "We use **Early Stopping** to prevent overfitting and ensure the model stops training once the validation loss stabilizes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fada7c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading data from: C:\\Users\\admin\\Desktop\\nlp-fake-news-detector-transformers\\data\\dl_features\n"
+     ]
+    }
+   ],
+   "source": [
+    "X_train, X_val, X_test, y_train, y_val, y_test, meta = load_features()\n",
+    "\n",
+    "experiments = [\n",
+    "    {\"name\": \"Baseline (Adam, 0.5 DP, 32 BS)\", \"opt\": \"adam\", \"dr\": 0.5, \"bs\": 32},\n",
+    "    {\"name\": \"High Dropout(Adam) (Adam, 0.7 DP, 32 BS)\", \"opt\": \"adam\", \"dr\": 0.7, \"bs\": 32},\n",
+    "    {\"name\": \"Large Batch(Adam) (Adam, 0.5 DP, 64 BS)\", \"opt\": \"adam\", \"dr\": 0.5, \"bs\": 64},\n",
+    "\n",
+    "    {\"name\": \"RMSprop (RMS, 0.5 DP, 32 BS)\", \"opt\": \"rmsprop\", \"dr\": 0.5, \"bs\": 32},\n",
+    "    {\"name\": \"High Dropout(RMSprop) (RMS, 0.7 DP, 32 BS)\", \"opt\": \"rmsprop\", \"dr\": 0.7, \"bs\": 32},\n",
+    "    {\"name\": \"Large Batch(RMSprop) (RMS, 0.5 DP, 64 BS)\", \"opt\": \"rmsprop\", \"dr\": 0.5, \"bs\": 64},\n",
+    "]\n",
+    "\n",
+    "results_list = [] "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "0b839310",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "early_stopping = EarlyStopping(monitor = 'val_loss',\n",
+    "                               patience = 2,\n",
+    "                               restore_best_weights = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "b7055eb8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running: Baseline (Adam, 0.5 DP, 32 BS)\n",
+      "Building CNN model (Optimizer: adam, Dropout: 0.5)....\n",
+      "Running: High Dropout(Adam) (Adam, 0.7 DP, 32 BS)\n",
+      "Building CNN model (Optimizer: adam, Dropout: 0.7)....\n",
+      "Running: Large Batch(Adam) (Adam, 0.5 DP, 64 BS)\n",
+      "Building CNN model (Optimizer: adam, Dropout: 0.5)....\n",
+      "Running: RMSprop (RMS, 0.5 DP, 32 BS)\n",
+      "Building CNN model (Optimizer: rmsprop, Dropout: 0.5)....\n",
+      "Running: High Dropout(RMSprop) (RMS, 0.7 DP, 32 BS)\n",
+      "Building CNN model (Optimizer: rmsprop, Dropout: 0.7)....\n",
+      "Running: Large Batch(RMSprop) (RMS, 0.5 DP, 64 BS)\n",
+      "Building CNN model (Optimizer: rmsprop, Dropout: 0.5)....\n"
+     ]
+    }
+   ],
+   "source": [
+    "def run_experiment(exp, X_train, y_train, X_val, y_val, X_test, y_test, meta):\n",
+    "    model = build_cnn_model(\n",
+    "        max_words=meta[\"max_words\"],\n",
+    "        max_len=meta[\"max_len\"],\n",
+    "        dropout_rate=exp[\"dr\"],\n",
+    "        optimizer=exp[\"opt\"]\n",
+    "    )\n",
+    "\n",
+    "    model.fit(\n",
+    "        X_train, y_train,\n",
+    "        validation_data=(X_val, y_val),\n",
+    "        epochs=10,\n",
+    "        batch_size=exp[\"bs\"],\n",
+    "        callbacks=[early_stopping],\n",
+    "        verbose=0\n",
+    "    )\n",
+    "\n",
+    "    metrics = evaluate_model(model, X_test, y_test)\n",
+    "\n",
+    "    exp_results = exp.copy()\n",
+    "    exp_results.update(metrics)\n",
+    "\n",
+    "    return exp_results\n",
+    "\n",
+    "results_list = []\n",
+    "\n",
+    "for exp in experiments:\n",
+    "    print(f\"Running: {exp['name']}\")\n",
+    "\n",
+    "    result = run_experiment(\n",
+    "        exp,\n",
+    "        X_train, y_train,\n",
+    "        X_val, y_val,\n",
+    "        X_test, y_test,\n",
+    "        meta\n",
+    "    )\n",
+    "\n",
+    "    results_list.append(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "821e35f3",
+   "metadata": {},
+   "source": [
+    "# Results & Ranking\n",
+    "After running all experiments, we compile the results into a table to compare performance based on **Accuracy, Precision, Recall, and F1-Score**. The experiments are ranked by their **F1-Score**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcfb16ec",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Final Experiments Ranking:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>opt</th>\n",
+       "      <th>dr</th>\n",
+       "      <th>bs</th>\n",
+       "      <th>accuracy</th>\n",
+       "      <th>precision</th>\n",
+       "      <th>recall</th>\n",
+       "      <th>f1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Large Batch(Adam) (Adam, 0.5 DP, 64 BS)</td>\n",
+       "      <td>adam</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>64</td>\n",
+       "      <td>0.793363</td>\n",
+       "      <td>0.781602</td>\n",
+       "      <td>0.807536</td>\n",
+       "      <td>0.794357</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Baseline (Adam, 0.5 DP, 32 BS)</td>\n",
+       "      <td>adam</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>32</td>\n",
+       "      <td>0.791467</td>\n",
+       "      <td>0.780212</td>\n",
+       "      <td>0.804758</td>\n",
+       "      <td>0.792295</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>High Dropout(Adam) (Adam, 0.7 DP, 32 BS)</td>\n",
+       "      <td>adam</td>\n",
+       "      <td>0.7</td>\n",
+       "      <td>32</td>\n",
+       "      <td>0.787848</td>\n",
+       "      <td>0.775741</td>\n",
+       "      <td>0.802819</td>\n",
+       "      <td>0.789048</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Large Batch(RMSprop) (RMS, 0.5 DP, 64 BS)</td>\n",
+       "      <td>rmsprop</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>64</td>\n",
+       "      <td>0.781539</td>\n",
+       "      <td>0.768328</td>\n",
+       "      <td>0.798840</td>\n",
+       "      <td>0.783287</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>RMSprop (RMS, 0.5 DP, 32 BS)</td>\n",
+       "      <td>rmsprop</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>32</td>\n",
+       "      <td>0.778176</td>\n",
+       "      <td>0.772374</td>\n",
+       "      <td>0.781468</td>\n",
+       "      <td>0.776894</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>High Dropout(RMSprop) (RMS, 0.7 DP, 32 BS)</td>\n",
+       "      <td>rmsprop</td>\n",
+       "      <td>0.7</td>\n",
+       "      <td>32</td>\n",
+       "      <td>0.771935</td>\n",
+       "      <td>0.763735</td>\n",
+       "      <td>0.779755</td>\n",
+       "      <td>0.771662</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                         name      opt   dr  bs  accuracy  \\\n",
+       "2     Large Batch(Adam) (Adam, 0.5 DP, 64 BS)     adam  0.5  64  0.793363   \n",
+       "0              Baseline (Adam, 0.5 DP, 32 BS)     adam  0.5  32  0.791467   \n",
+       "1    High Dropout(Adam) (Adam, 0.7 DP, 32 BS)     adam  0.7  32  0.787848   \n",
+       "5   Large Batch(RMSprop) (RMS, 0.5 DP, 64 BS)  rmsprop  0.5  64  0.781539   \n",
+       "3                RMSprop (RMS, 0.5 DP, 32 BS)  rmsprop  0.5  32  0.778176   \n",
+       "4  High Dropout(RMSprop) (RMS, 0.7 DP, 32 BS)  rmsprop  0.7  32  0.771935   \n",
+       "\n",
+       "   precision    recall        f1  \n",
+       "2   0.781602  0.807536  0.794357  \n",
+       "0   0.780212  0.804758  0.792295  \n",
+       "1   0.775741  0.802819  0.789048  \n",
+       "5   0.768328  0.798840  0.783287  \n",
+       "3   0.772374  0.781468  0.776894  \n",
+       "4   0.763735  0.779755  0.771662  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "results_df = pd.DataFrame(results_list)\n",
+    "\n",
+    "results_df = results_df.sort_values(by='f1', ascending=False)\n",
+    "\n",
+    "print(\"\\nFinal Experiments Ranking:\")\n",
+    "display(results_df)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8bcb8f18",
+   "metadata": {},
+   "source": [
+    "# Visualizing Performance\n",
+    "A graphical comparison of the F1-Score across all experiments to clearly identify the top-performing configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "d6e1d180",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\admin\\AppData\\Local\\Temp\\ipykernel_17120\\382017120.py:2: FutureWarning: \n",
+      "\n",
+      "Passing `palette` without assigning `hue` is deprecated and will be removed in v0.14.0. Assign the `y` variable to `hue` and set `legend=False` for the same effect.\n",
+      "\n",
+      "  sns.barplot(x='f1', y='name', data=results_df, palette='magma')\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABQ0AAAIjCAYAAACphT1RAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAukxJREFUeJzs3QV4FNf79vGzSYAADVpatFC8Qt2h7u6l7k4N6kKh1N3dXai7O/VCW2q0RQoUdyjFsvNe9/n9J+/sZpPsLgm7T/L9XNc2ZXVm7tmFffKcc2JBEAQOAAAAAAAAAP5PQfg/AAAAAAAAACAUDQEAAAAAAAAkoGgIAAAAAAAAIAFFQwAAAAAAAAAJKBoCAAAAAAAASEDREAAAAAAAAEACioYAAAAAAAAAElA0BAAAAAAAAJCAoiEAAAAAAACABBQNAQAAjLj++utd586dXWFhoVtvvfVyvTkw7uOPP3axWMz/BELffvut22KLLVzjxo39+fHDDz9Uy/N26tTJHX300XXu/Bs8eLDfTwCwiKIhAABAlh555BH/ZTC8FBcXu+7du7vTTjvNTZ06tVpf691333XnnXee6927t3v44YfdVVddVa3PX1epYLHffvu51q1bu/r167tVVlnF7bnnnu7FF1/M9aYhhbDQlOpy8MEHl93vm2++caeeeqrbcMMNXb169bIq2owbN84dc8wxrkuXLv69rXNkq622coMGDXK11dKlS92BBx7oZs2a5W6++Wb3+OOPu44dO1b5uDfffNMf47Zt27p4PF6jn7PJl6+++qpaX6+u0t8pL7/8cq43A0CeKcr1BgAAAFg3ZMgQt/rqq7tFixa5zz//3N19993+S/TPP//sGjVqVC2v8eGHH7qCggL34IMP+uIWlp+KP8quW7du7qSTTvLFkZkzZ/rs9t9/f/fkk0+6Qw891NVWKoD9999/Js+nM844w2288cblOtlCyvCBBx5w66yzju/O/eOPPzJ6/r/++ss/f8OGDd2xxx7rn3vy5Mlu+PDh7tprr3WXXXaZq41Gjx7t/v77b3f//fe7448/Pu3H6b2iY6RCqz6rdthhhxr7nE3WtWtXl88uueQSd8EFFzgLRcMDDjjA7bPPPrneFAB5hKIhAADActp1113dRhtt5P9fX7RbtmzpbrrpJvfKK6+4Qw45ZLmee+HChb7wOG3aNF/AqK4CTxAEvsip56yLnn/+eV+E0Jfkp556ynejhc4991z3zjvv+K6r2ki56zxSEVoddBZtueWWPruKnHLKKe7888/357c6fzMtGqrLbsGCBX5obnKnnd6LK9K///7rhwqvCOG+NWvWLKPt02fd1Vdf7bugVUCsiaJh9HPWgjC3oqIifwEAixieDAAAUM222247/3Ps2LFl1z3xxBN+qKSKGC1atPBDKSdMmJDwuG222catvfba7vvvv/ddYCoWXnTRRX4Inr6M60toOCRPQ/Zk2bJl7vLLL/dDKBs0aOC7ffSYxYsXJzy3rt9jjz18MUxfvLUd9957b9lwz+eee853T7Vr186VlJT4gszcuXP985x11ll+2O5KK63kh2smP7e2Tfus+2gb1lxzTd9tmSzcBnVjbrLJJr5gpS6wxx57rNx958yZ4/r37+8fo+ds3769O/LII92MGTPK7qPtULegOo10nw4dOvgh3Mnbl8rAgQN9Dg899FBCwTC08847+22NFlOOO+44t+qqq/rtXnfddd2jjz6a8Bh1WelY3nDDDe7OO+/0+6YMd9ppJ5+1CrXKSvui47/33nv7YaCpjpGGo2veSr2WjmfycGk97pxzznG9evXyuTRp0sQXVX788ceE+4X5PvPMM77jSflqm+bNm5dyTrk///zTd1lqKK5eW9uqc1XnQijTcy6dvNXhpkt1UU7LUxDXtmjfUw3N1Xme7K233nJbb721f+8oC3UpqhgdNXTo0LLPgJVXXtkdfvjh7p9//km4j+b8U556/d12280/32GHHeZv07DfW265xa211lr+WGof1SE7e/bstPZJHYAqtqqQpaKgzr/ffvst4bW1D6Ihyjo39JlUlZdeesl3rOoxOld0rqowvaLps0CF8A8++CDh+hNPPNEXycP3RnjeP/vss/681bmuY7LXXnuV+0yWr7/+2u2yyy6uadOm/r2jYzRs2LCU8xb++uuvvju5efPmrk+fPgm3RenPKmbrnND7W+fE5ptv7kaOHOlv12ezPteUszLQZ8vybJc6Z5Wvctf99TmuX0hFt0d/v+gzLfw7Jpx/cv78+f7vgPCzWOf/jjvu6LtuAdR+/MoDAACgmoXFD3UcypVXXumLVAcddJDvRJw+fbq7/fbbfWFwxIgRCV09Gh6r4o++fKuooMKAinz33Xefn6dNQy5FCxWInk9f9FTkO/vss/0XSXX8qBigL/NRo0aN8p2PKjSccMIJrkePHmW36TH64qphdPqCqe1TMU1fwlWU0JdPzR2mYqWGCF566aVlj1WBUIUMfelWR81rr73m55NTkaNfv34J26Dn1raqAHfUUUf5op2+nKqYoucQdXipuKF90NDQDTbYwBcLX331VTdx4kRfcNFz6/VUkFJRYI011vBfuNUhpq6yyubmUmHs999/98+tokxVVBDRF3dtu77oa//1ZV/breLmmWeemXB/dVotWbLEnX766b64d9111/nsVVhVwUIdcOExVuFPxyB5+/r27etOPvlkf4xUlFVB5u233/Zf1mXMmDF+H3W9tkdzaKrQoMKBCheaWy5KRT4VTvR6Ku6l6ljVNqtYqtu17SqmqKj1+uuv+/1UsSHTcy6dvGX77bf3P1MVR1JRISNaQBYVgXW+VgcVC99//31faAt/CVARvSd0Lml/LrzwQv9+1vtaeYXD23UfFWpUTNSxUl633nqrL/IkfwaoKKscVHRSATqc4kDv2/B5NDxbv5S44447/OP1PKmK3yHtiz5XVLTVe1nntM4/zZGq4o8KQnp+FZU1TDUc/q3Pn6rofN922239+aLPLX2G6DNA52Z1UuE6OXMVt8LPWRXF9bo61/RZoPe2fkmiodY6/1Xoj9Lnsh6v96N+KaCCrDok1V0aFpyVv46bztewKBn+kuSzzz7zxfAo7bOmO9Ax1C8JKqPH6zMt/IzUeaEiu37xcdddd/nPUH326vND55e2JZTpdunzR58Teg3lrb9HVPzTUHvR3JV6X+tx+jwV/VJA9Dmkzmx99qnAqb+j9Lmr97s+mwHUcgEAAACy8vDDD+tbYfD+++8H06dPDyZMmBA888wzQcuWLYOGDRsGEydODMaNGxcUFhYGV155ZcJjR44cGRQVFSVcv/XWW/vnu+eee8q91lFHHRU0btw44boffvjB3//4449PuP6cc87x13/44Ydl13Xs2NFf9/bbbyfc96OPPvLXr7322sGSJUvKrj/kkEOCWCwW7Lrrrgn333zzzf1zRS1cuLDc9u68885B586dE64Lt+HTTz8tu27atGlBgwYNgrPPPrvsuksvvdTf78UXXyz3vPF43P98/PHHg4KCguCzzz5LuF3HTo8dNmxYUJFXXnnF3+fmm28O0nHLLbf4+z/xxBNl1+lY6VistNJKwbx58/x1Y8eO9fdr1apVMGfOnLL7Xnjhhf76ddddN1i6dGnCMa5fv36waNGicsfohRdeKLtu7ty5QZs2bYL111+/7Do9prS0NGE79fo6lkOGDCmXr7JIzim8TT9lxIgR/s9Dhw6t8Fhkc85VlXd43+TzKpVwm1NdtP+p9OvXz9+eiZ9//tm/h/W49dZbLzjzzDODl19+Ofj3338T7qecS0pKgk033TT477//Up6rOldWWWUV/x6L3uf111/3z6/zPfo+13UXXHBBwnPpPNf1Tz75ZML1ej+nuj6Z9kHbMHPmzLLrfvzxR/8eOvLII8sd38rOgaipU6f6z7H777+/7Lotttgi2HvvvcvdV/lq/yo6/6r6nE110bmU/Lmq95TOz9mzZwft2rULNtpoo4T3Xfi6ui1878pzzz3nr7/11lvL8uvWrZv/LAuzFL2PVl999WDHHXcsu27QoEH+sXpPJwtviwq3PXrO3nvvvf761q1bJ2xX+PkR3jeb7Tr22GMTXn/ffff1f09F6e+XaD6hpk2b+vcQgLqJ4ckAAADLSd0prVq18sNj1Wmj4YXquFLXjobqqStOnR7qkgkv6spRR8pHH32U8Fwa/qVOonRosQcZMGBAwvXq/pI33ngj4Xp1mqiDKRUN/Y12Km266aa+U0YdLlG6XkP41A0Vig4DDbuB1PGmbrjosFZRp4q6CEM6bup41H1DL7zwgu8K2nfffcttZzjMT51+6i7s2bNnwnENu8KSj2uUhuZKOl2G4XFWXtH5KXWs1I2lrshPPvmkXLdR2JUXHjNR52h0bjNdr+6+5CGq6hKM7ruGuyofdZRNmTKl7DwJu+pKS0t994/OOx3LVMMG1eVX1XDdcJvVnRUduph8LDI559LJO+wwTLfLUNTp+t577yVclFF1UdegOs6UmbZLXYFaIEKdd+pcC+l11fWo7rrk+SHDc/W7777znWzqHIveZ/fdd/fnb/IxC+dkjNL5rnzUaRo939VpptwrO9+1gIv2RR2e6sYMaZEYPV+YaTY07F3noYa0h/Q+0XDtdIdNp0tD/pMz1+tEaXoHTbOgTjp91ukYqSs21ZyCek9FPwPUEdumTZuy46Fjpq5fdYvq/RUecw3jVWfsp59+Wm6laHXlpUvPEV28J/yc0LGMbld4ffieqY7t0ntSjw0/CyujLlh1E0+aNCntfQNQezA8GQAAoBq+zHbv3t1/MVVRQUWRsKCjL3cqvqlAmErykEIVGtNd7ESrnOp1klcPVfFEX/R0e1SqlUdDq622WsoCkgqhydfrC6mKgeGwQA2N1BC5L7/8slyxSfeLFtCSX0c0/1e0wKDh3dEiRCo6rhoepyJUKpUtVqEinKjYkw4dR+WXPPRVRcvw9myPpSQXV5Rn8hxoOr9EBSzlqwxUyNIwRg1TVeEwFOaSbvbR+6gYqEV8NORUhQUNAVfhLNzWTM+5dPLOhuZyrI7FNsIibEj7GRZXdcw1bFPHVkO+NUxbQ0U1fFPHSq8fTkWgYlVFwmMSnQ4gpKKhhnpG6XNE8ykmn+96L6WaT7Gq872y19c5rCJxtoutaK5WDWlVAUoXWX/99X0xXIXOcKhrddDrpLMQihYyUjFT0zlomLAK16kkfybrPafzOixe65iHBfeKKBOdz5m8z5b3cyKb7Up+rfA2PWf4eVgRnfN6LW2XitSaa1MFVw11B1D7UTQEAACowS+zKu7oy6g6YgoLC8vdri6hqGwWb0guMFWksudOtW2VXR/O16WiibpbVPxQsUlfLFX0VLeO5hdM7nip6vnSpedV4UivmUryF+8obauEiw5Ut2yPZSZUDNE8meoE1Xxt4Xx+WrAg+Zhncl7deOONviNNq+FqMRZ1U2oeNM1nGS1kpXvOVec+1wR1lkVpXrhwAYjoPuhc00WLVWj+vppaITi5izSkTFUw1OumUlHxvCapePXtt9/6/0/1SxFta3UWDdOljrywsLY87/HwfXT99df7RYlSWZ7P72w/J7LZruV5H6pLXr9AUPe8PhP0upoLUV30mlcRQO1G0RAAAKAGaTJ5fTFTB0rYLVZdtFiDvkDqC3LY9SZaZEELV6Ra+bW6aeEBLZyhCf2j3SyVDZdM55j9/PPPVd5Hq6GqYJluASukHNR1pcKYuvWSv2An03H86aef/LGOFnO0mEp4e3XS4iE6Z6L7pcVdJBzOqIUJVLx68MEHEx6r3LVQzPIIC2RaWOKLL77wi2Xcc8897oorrsiLc646aYhrVHRxllTCXw5oyG90sQidr8ndl6HwmGghouRFVXRdOsdMr6PFTJRFpr9YiL5+Mp3DOl+y6TJUUVCd0urGTC5KqXvytttuc+PHj0/ZbVpTdG6q6KvuORXQVVzXsOP99tuv3H3DwmJI7zm99zRsO5qtnqumCsTZqKntquxzVMV1Da/XRV2tWgBFC8lQNARqP+Y0BAAAqEH6sqov1JpnK7mrQ38Oh/RlQ8PERKt+RoXdd5ozraaFxYLovmlonDq2sqWhySoIJq/EG30ddb9oLsDo/HIhrQyr4ZaVUR469loxNDo/Y0gdNRqOGh5nDWN99tlny27XY7T6rAqOmr+xOmnusOi+a96xxx57zHcVhfP26bgnn08aDpo8P2Im9DrJx0LFQxVKVRiuyXNOHavhUN8VSUWX6CXsPNQKtEuXLi13/3C+u3Co70477eTnn1M35qJFixLuG+ajQqO6BFV4DY+jqPtYQ+zTOWY63zVMWl2lyZSZCrYV0T7p3NHcftH7qdCp8zzMNFPhEHat9K3CXPSiIcLy9NNPuxVJ56EK3VptXsdKq8xrfsjkVZdF76noFAUqxKsYHBbCNBRXBTqtYK25S5NNnz7d5UJNbZcKx8nnkc655HlpdS5r3tXouQyg9qLTEAAAoAbpy506tC688EI/V5YWU1CRQfPQqTCk4XvnnHNOVs+txUI015S+IOvLnopXmsdLxQG9jjrRapqKJhqOvOeee7qTTjrJf4lVIU9fLMNurEyp4KAv8FpQRMNv9SV51qxZvptRhRft9xFHHOGee+45P8G/uhrVgaUvuOqc0vWap62y+c9U6NDQRXXLaIERLd6gjiwVEt9++233wQcfuKeeesrfVxnde++9voPp+++/991+2j7N5ajiWboLqmTSCXncccf5oZ+aI/Ohhx7ynXzRQuwee+zhhgwZ4hfNUWFE+6IizvLMM/bhhx+60047zR93bYOKUWEXWTjHZE2dc+oYlUwWQ6mM5vHTtocLkYjeh6Kcdf5URsMvlbWK/mHnmRaYUaFJQ8HVxRZ2e2kYvorPG2+8sV+cQvPFqeit+T11XNSNp+dTVjpeOteUp7pcdS7179+/yv3R4/T+UnFSC2HofafnVbecisV6LhXrKqIhpSqGaXi1zi0V1lX01nx5gwcPdpnSwhjqytP5kormZlU3ms7J888/31UHFVnD7t4onf8671WA1ZB9vU/1eSSPPPKIL5iqQ06fC1HKsU+fPj4X5aH3srpFTzjhBH+7iuVaUEXHTR2oup/2S4V5feYoe3Var2g1tV36nFU3qwqvKgqqO17FcU1LoHNL7339kkT30WeTpjIAUAfkevlmAAAAqx5++GG1EgXffvttlfd94YUXgj59+gSNGzf2l549ewb9+vULRo0aVXafrbfeOlhrrbVSPv6oo47yj0u2dOnS4LLLLgtWX331oF69ekGHDh2CCy+8MFi0aFHC/Tp27Bjsvvvu5R7/0Ucf+X0YOnRoWvs2aNAgf/306dPLrnv11VeDddZZJyguLg46deoUXHvttcFDDz3k7zd27Ngqt0H7rUvUzJkzg9NOOy1o165dUL9+/aB9+/b+GMyYMaPsPkuWLPGvpWPWoEGDoHnz5sGGG27oj8fcuXODdHzwwQfB3nvvHayyyipBUVFR0KpVq2DPPfcMXnnllYT7TZ06NTjmmGOClVde2W9Pr169/DGK0r5qn6+//vqsj3F4jN555x1/TLVfOleSH6t8zz777KBNmzZBw4YNg969ewdffvlluWNZ0WtHb9NPGTNmTHDssccGXbp08Vm2aNEi2HbbbYP333+/Ws+5VHnrvrpUpbL9SXW/VJfk105l2LBh/v259tprB02bNvX7udpqqwVHH310MHr06HL313tgiy228Fk0adIk2GSTTYKnn3464T7PPvtssP766/tMdWwPO+ywYOLEiWm9z0P33XefP8f1OiUlJf48PO+884JJkyZVuU/KUedJuI06z3/99desju/pp5/u75fqWIQGDx7s7/Pjjz/6Pytf7V9F519FwvdJRRfdvmzZsmDjjTf2nxNz5sxJePytt97q76fjH31d5aPzVu99HROdq3///Xe51x8xYkSw3377BS1btvTZaT8OOugg/9lR2edi8m1R+rPOr+X5/Fie7QqPafTz+ffffw+22morfyx0m7JavHhxcO655wbrrruuP990bur/77rrrgrSAlDbxPSfXBcuAQAAAPxvzkKtxBsOjQZQvT7++GPfEasOzcq6MwEAzGkIAAAAAAAAIAlFQwAAAAAAAAAJKBoCAAAAAAAASMCchgAAAAAAAAAS0GkIAAAAAAAAIAFFQwAAAAAAAAAJihL/CABYUeLxuJs0aZIrKSlxsVgs15sDAAAAAKjlgiBw8+fPd23btnUFBZX3ElI0BIAcUcGwQ4cOud4MAAAAAEAdM2HCBNe+fftK70PREAByRB2GMm7cONe8efNcbw4yVFpa6n755Re31lprucLCwlxvDjJAdraRn11kZxv52UV2tpGfXaV5mt28efN880r4fbQyFA0BIEfCIclNmjTxF9j7R8BKK63ks8unfwSgamRnG/nZRXa2kZ9dZGcb+dlVmufZpTNFVizQYGYAQE5+w9O0aVM3Z84c/xO26K/PRYsWueLiYuakNIbsbCM/u8jONvKzi+xsIz+7gjzNLvweOnfu3CqbV1g9GQCALNWvXz/Xm4AskZ1t5GcX2dlGfnaRnW3kZ1d949lRNASAPFhFGTZzGzlyJPkZRHa2kZ9dZGcb+dlFdraRn121ITuKhgAAAAAAAAASMKchAOR4Loke7XZyQZzf4VhTVFTo9jqot3v1uWFu2bLSXG8OMkB2tpGfXWRnG/nZRXa2kZ8Noya9lXIhFHUa9urVK68WQmFOQwAAAAAAAABZo9MQAHL8G54uq+7gCguKcr05yPI3v/zG1yays4387CI728jPLrKzjfxsdhoGQeDnMywoKGD1ZABAdvLo7w9kmFujxg3IzyCys4387CI728jPLrKzjfxsW7JkibOMoiEA5FhhIR/FFmlekh123yiv5idBesjONvKzi+xsIz+7yM428rMrHo+7UaNGsXoyAAAAAAAAgNqDoiEAAAAAAACABBQNAQDI0rKlTEhtFdnZRn52kZ1t5GcX2dlGfnYVGh9WzurJAJAjrJ4MAAAAALVz9eR8xerJAGAIK6HZzW3VNs3JzyCys4387CI728jPLrKzjfzsCoLAF+gs9+pRNASAHGP1ZLtDDXpv28v8kIO6iOxsIz+7yM428rOL7GwjP7vi8bgbM2YMqycDAAAAAAAAqD0oGgIAAAAAAABIQNEQAHIscHbnuKjruc2fu5D8DCI728jPLrKzjfzsIjvbyM+24uJiZxmrJwNAjrB6MgAAAADYN4rVkwEANaGAT2KTCgpirlOX1v4nbCE728jPLrKzjfzsIjvbyM+ueDzuZs6cyUIoAIDsFVA1NJvbBpt2Jz+DyM428rOL7GwjP7vIzjbysysIAjdhwgT/0yrOOgAAAAAAAAAJKBoCAAAAAAAASEDREAByjJXQ7OY2dfJs8jOI7GwjP7vIzjbys4vsbCM/20pKSpxlrJ4MADnC6skAAAAAYN8oVk8GANQE5jS2SSvYrdGrIyvZGUR2tpGfXWRnG/nZRXa2kZ9d8XjcTZkyhdWTAQDZYyU0u7n97x9w5GcN2dlGfnaRnW3kZxfZ2UZ+dgVB4IuGlgf4ctYBAAAAAAAASEDREAAAAAAAAEACioYAkGPxuN129bqe27jRmqOE/KwhO9vIzy6ys4387CI728jPrlgs5lq0aOF/WkXRsI7aZptt3FlnnVXl/T744AO3xhpruNLS0uV6vY8//ti/UebMmeNq0q+//urat2/v/v3337Tuv9VWW7mnnnpqhR1P1F4HH3ywu/HGG7N6LP8AsEkTGg//+g/TExvXVWRnG/nZRXa2kZ9dZGcb+dlVUFDgVlttNdPzUdrd8hSOPvpot88++zgrVEQLL0VFRf5kGjBggFu8eHFGz9OpUyd3yy231Mg2nnfeee6SSy5xhYWFCdf/999/vmK+8sorZ7y9NWnNNdd0m222mbvpppuqvO+rr77qpk6d6os9ya6++mq/z9dff72zZtGiRa5fv36uZcuWbqWVVnL777+/38+q3jvR81GXXXbZJe3H1KtXz6266qpuxx13dA899FC5v9B0job3bdy4sdtggw3c0KFDM9633377ze21115+eXg9z8Ybb+zGjx9f7n6aaHbXXXf1r/fyyy9XWfCN7rf248ADD3R///132X1UNL/mmmtcz549XcOGDf25v+mmm7oHHnig7D56n1x55ZV+2fpMsRKaTfrLf4NNu5v+R0BdRXa2kZ9dZGcb+dlFdraRn13xeNx/X7Vc8OWsq4QKBTUd7sMPP+wmT57sxo4d6+666y73+OOPuyuuuMLlg88//9yNHj3aF52SvfDCC26ttdbyRZSqijIr2jHHHOPuvvtut2zZskrvd9ttt/n7pvrwVeFLBVP9tKZ///7utdde80W5Tz75xE2aNMntt99+VT5ORUKdi+Hl6aefTvsx48aNc2+99Zbbdttt3Zlnnun22GOPcsd/yJAh/r4jRozwxb6+ffu6L774Iu390rnYp08ff86pc/Wnn35yAwcOdMXFxeXuqyJ6Ji3gJ5xwgt82HatXXnnFTZgwwR1++OFlt1922WXu5ptvdpdffrnvZv3oo4/ciSeemNA5u/baa7suXbq4J554wmWKoqFNyq1Tl9bkZxDZ2UZ+dpGdbeRnF9nZRn52BUHgZs2axerJVqj7rFevXr5DqUOHDu7UU091CxYsKLv9kUcecc2aNfMdaOpYa9Cgga8Kq5iw++67+w6j1Vdf3Q9nTe7uU/Hg+OOPd61atXJNmjRx2223nfvxxx+r3Ca9XuvWrf32qNCy9957u+HDhycUSnSdup/UNaZiy/vvv5/QJaWOKBWKwk6p0LBhw/ztjRo1cs2bN3c777yzmz17dtntKoiqMKauKW3D4MGDE7btmWee8Z1jqYoyDz74oC+q6KL/T/bmm2+67t27+2OmQpKKSlEzZ850hxxyiGvXrp3fPuWSXKTStp9++ul+2K+2X8fg/vvv90OPVewrKSlxXbt29cWqKG2z3pgqmFVk+vTp7sMPP3R77rlnudv0OHVSqsg1b968coUtvf6RRx7p82jTpk3KIakq/m600UZ+G3VsDz30UDdt2rRyw7Xfeecdt/766/vjpHNG99H+aEi4ziM9buHChS5d6nJTHjrX9XwbbrihL0xrH7766qtKH6vzXdsaXnTMqxI+Rjmqe/Ciiy7yRTftg95PUeGx0Hlx5513+n1WcTNdF198sdttt93cdddd54+ZCnTqOlxllVUS7vfDDz/4TDIp+Ooc1LYpT3WqnnbaaQnvQ30m6PNCHYj6DFh33XXdcccd584555yE59H5pPcNAAAAAADW1amioTrK1F32yy+/uEcffdQXjVQ0i1KB5tprr/XDDnU/FSRUIFIHkgo96rC77777EgpAomJCWPD5/vvvfQFl++2398WrdP3xxx9+mzTsMaSipgolmltQHVrq7FJhIhyS+eKLL/o5/MIuLl3CwoleX8XPL7/80ncN6nHRuQl1DFRA/frrr30hRs/x3nvvld3+2Wef+cJXMhUy9ZwHHXSQv+h+0aGc6tJSZ5teT9uhYuoFF1xQbgitClpvvPGG+/nnn33X1hFHHOG++eabhPtpGzUEWtergHjKKaf4Y73FFlv4os5OO+3kHxctrNWvX9+tt956frsqouOhQpGKc8lUdFNBU0Nu9TO5KHruuef6wqKKY++++64/L6IFJlm6dKnvSlPhWJ2YKppqOG8yFWrvuOMOX9TTcdPxVDFahWkdGz3/7bff7tKlc0+vvcMOO5Rdp848DX1XZpXRfuh879Gjhz/OKuxmQ8VKFdV0blZEw/F1fJcsWZLWc6rAreOhgqOK39pOvU+Su1x1HqjQqqKkioDZ0Hv2ueeeS3gf6rn03lSxuTKbbLKJP1crGrKv61WIjl4AAAAAAMhHdapoqI41db2pS1CFDQ0DVnEgSgUXDRNWUUrFExXn1NmnDjcVEVQMVEFRnWjRApQKBRoOqiJbt27d3A033OC7CJ9//vlKt0lFKXWsqZtPr6chvxdeeGHZ7Sq+nHTSSX7oo55XhSh1WKnzSdQlqLn3wi6usFCiIqC2Rfui59DzqntKBbjQOuus4wYNGuSfV4VR3V/FyZAKgW3bti23zerg0nxx6kTT66uIo262kIYGaxvV7aV9Ouyww8oVzNSZpi4tFfc6d+7sC4IqiCbnoW3XXHHaRh0XHSftg4aT6rpLL73UF7c0VDVK2x0tZCbTbepcTB6arCKOMguHpuqntinsSNVPFRGVr4qy6pBUYTN5KO6xxx7rj5H2TZ1rKlaroBztbBWdg7179/adc+pcUzFSx09/3nLLLd0BBxzgh8Kma8qUKb5oqnMvSvuq2yqiY//YY4/5/FU013Zo+7NdAEeFyuTu0pAKhZozUl2Reh+mQwV5HTvNK6htVTF133339cXpaEepOm713lV3bib0PtH7UEV0zQU5atSohE5FdW6qYKj3l943J598crkO1/C80/5VdKy135qPMbyow1gsz3FRlym330b+TX4GkZ1t5GcX2dlGfnaRnW3kZ1csFvPfIVk92QgV/1ToUcFKRTZ1qKnglNylpqJASMUDdUWpWBjSkNjo0E11k6mgES48EV40T6G68iqjedLUjafneP311323obYrpOdVcU0dcSoE6Xm1GESqxR+iwk7DykT3UzQ0M9pBqcJo8tBkFZFUJIvO96b/11DU8ENM2xft0pLNN9+83POoAKqimwqP2i8N1U3er+g2qjiqY6zHRIthktz5qaGvlQ3rTbVvoiHSKniqWCkqanbs2NE9++yz/s/KU0Wh6P5p+1UcTe74U6elOvx0rm299db++sr2T/ui7kcVGqPXJe9bTdBiMBrqq2OrxYR0Ln777be++zAbmrMh+YPx/PPP9zlrH1WYVAFQw/7TEZ5bKgaqMKhc1L2qIf333HOPv02FdHUDZrMokArb4ftQvwTQe1xdrPPnz/e3q2NXHbEa4q2CsDJRvuqiTT7vpKJzT4VvFUvDi7pL/7d/GW8y8oBWvf7fP+DszlFSV5GdbeRnF9nZRn52kZ1t5GdXQUGBLxpaXsTG7pZnSF1PKjCoSKMhxirqaAijRIdI6kt/plVgFfZUcFPRIXpRwVFDWSujE0gFChWdVEDRggsqUP3111/+dhUMX3rpJXfVVVf54bZ6XhV2qhrWGRYvKqPhoVHa7+hvL9TRF50DUVTY++eff/wiFiqm6qKCkzr3ol2KVdGqxLfeeqsvJKmTTvuljsXk/Uq1jdHrwqySf+uiIaaaX7IiqfZN1EWoYenhvumihS8ymR9Pcx5qXzQn4ZNPPumLb8pQKtu/5H0Lr8vkN0o6n/Qa0QU6RKsnZzJcV4VLHaPwPMyUCsea+y9K7wXlPHHiRH/slX26tC3KQsW7KBXTw0KsCoYq6qq4HmYnWshH82NWRl1/eh/qos5PnQd//vlnWbFY9EGvOUXVsayh1yqU63765UAonI6gonNPc0DqvIhepLDI7m+e6rLCogLXe9te/idsITvbyM8usrON/OwiO9vIz67S0lL/HTXbEXz54H/fqusAFQlVfNGQ2bDKmzwUNhUV8zT0VPMJag4+USElWnBSF6KGI6pIoaHPy0PddBIOf9ZiJhraq6GYYYEyedinuiOTT0IVR1XEUxEyWxoiq4JZlIokKhJqUYqoK6+80t+mRUhUyAmHT4eSF+HQfqlrLOxYVDbqskwuCmVLXWEa2lvZvikz5Rh2jY4cOdJ99913vrtO3YPRQpCKTr///rvvQlRhT/NAqotQ9Bza9rCbUPdTB6s66cLhp3reFUHnqLZP2YerXqt4rcJacrdnZVTY0z6oGJ4pFe90LNURmFz4U1EuGzrHVbDTvkTpuKsTVNR5mNz5pwK7unlTLXiTyfswlfBcVZE4et5pjtHoNADpiLmY4/eG9ii3Vds09z9hC9nZRn52kZ1t5GcX2dlGfrbN/7/Ra1bVuqKhhvypmylKQ1pVrNB8hVpUQgUEFa3CYY1Vzc2mRSW0UIfmmlNB5uyzz07oSNTtKshoWKfmEtRiDVo4RQs3qNiXajGRkDrCVLxS0UydTVqMRI8PF+jQvH3qatI26/UGDhxYrvNMhcpPP/3UF/PUyaSChYZBqmCiFV81/5qKLuro0yIi6RY01C2nocghzemm1W5VENQci1GaE1H7qgKbXk/FWXWWqYijgm3ySrraL80dqAVAVLTTnHHqhquOoqGKquqGjC4GkqpoqOOg80AdqKKipxay2GqrrcrdXwUr3a4OSc09qH3TeaUFOVRAjbYbq5io461zTcdChSQNxV4R1DGn7RswYIAvfKqTTfNF6vzU3IrR81rz6ykzFaJVXFaRUd2I+k2IFgjSe0bnQGW0sIfOXxWtld/bb7/tn1fHVOdEddIxV4er8tHcpHotnY/hEOronJ5RyiO56zGZhhOH8xBqP5SXhq9riLKoAK0ORM2XqNdQd6HeY3qv6liG1A0cPgYAAAAAAMtqXX+rCggqCEUvKohojjoVpjSXmgpeGjaq4kY6tECE5pZTsUJFFi3CoXnqwjnxVMx78803/e3HHHOMLySEQ3bDOfcqovurm0vdSVoURQuWaIGFcGiltllFNRUrVDhUESc6v6Ko0KhCmbrgwmGR2gYtFqE52lQIU9FIq/2Gz5vuPG8aqht2d+k4aKGIVHMl6joVUp944glfpNEQcK1sq+Ou4qyGV0dpcRPth/ZHXXwqxKjoWh00L6EKN2EHWkWdZDr2Og9EQ3q17WF3XjJdr/1X4VmFQy1SojxUmOzTp09ZF6ooAxVJtTCOiqDqONTCKdVBz1vV8Hl11qlop23WOaljm7ySsTJVgT08FlpIRnMa6rxR0VH7owKYitCVUeFO568K11qgRIVpLfqicy3s1kv3fav9qmjxFNF7T+eSCvMqiGtBIp1nOv7LSwsdaT90UUFyxowZ/j0dzlWp81QFSmWuY3TUUUf5YqHeY+F7SiuC65zX5wMAAAAAANbFAq1YgIxo6KaGnYYLq9Rm6u7SisL33nuvs0DFP3UxPvXUU74zrDLqLFORdvjw4ZUWGPOJVrvWasHZLlCSr7T6tgrLGg6fPK+jFepE1tyVKiSmS+8tdYd2a7ODi9W+xu9ar6Ag5lZbfVU3fuxUJqY2huxsIz+7yM428rOL7GwjPxtGTXqr3HUaJRpOiZZPi6GE30PVSBTOs1+R/NnqPKY52jQkV0MSNZxWXYTqrEo1jLW20dBbFdSsLO+uufsuuuiiKguGog48DTmuaiXqfKIuVHXa1Tbq6lPR0GrBULTtGpKeDSNvLyTRP9rGjdb0EvzjzRqys4387CI728jPLrKzjfzsKigo8NOa5VPBMFN0GqZBKwZrHsMxY8b4YckaKnzLLbeY6U4DkJ/C3/B0b7ejc/H0h3MjP2gFu+123sB9+M5wV7qMyq8lZGcb+dlFdraRn11kZxv52e00LC0t9WtXaDRkJtN35VOnIePh0qD5zKpaEAIAssXqyXZzK2naiJXsDCI728jPLrKzjfzsIjvbyM+2RYsWOcvs9kgCAAAAAAAAqBEUDQEAAAAAAAAkoGgIADlWWsrcJBZpjpJhH430P2EL2dlGfnaRnW3kZxfZ2UZ+dhUUFLjOnTubXgiFOQ0BIMf8clRMUWIyt6mTZ+d6M5AFsrON/OwiO9vIzy6ys4387IrFYlUuNJLv7JY7AaCWKCrio9iioqJCt9eBvf1P2EJ2tpGfXWRnG/nZRXa2kZ9dpaWlbuRI212ifFMFACBLRfX4x5tVZGcb+dlFdraRn11kZxv52VVquGAoFA0BAAAAAAAAJKBoCAAAAAAAACBBLAj8FPwAgBVs3rx5rmnTpq5r6x1cQYx1qayJxZwradLIzZ+38H+L2cAMsrON/OwiO9vIzy6ys438bBg16a1y16nctmjRIldcXOwXRcm376Fz586tcqEWOg0BIMf4y99ubgv/XUx+BpGdbeRnF9nZRn52kZ1t5Gdb/fr1nWUUDQEgx1g92fBKdgexkp1FZGcb+dlFdraRn11kZxv52RWPx/3qyfppFd9UAQAAAAAAACSgaAgAAAAAAAAgAUVDAAAAAAAAAAlYPRkAcrxqVZdVd3CFBayebJHmllm2rDTXm4EskJ1t5GcX2dlGfnaRnW3kZ3f15Hg87goKClg9GQCQnTz6+wMZ5taocQPyM4jsbCM/u8jONvKzi+xsIz/blixZ4iyjaAgAOVZYyEexRYWFhW6H3TfyP2EL2dlGfnaRnW3kZxfZ2UZ+dsXjcTdq1ChWTwYAAAAAAABQe1A0BAAAAAAAAJCAoiEAAFlatpQJqa0iO9vIzy6ys4387CI728jPrkLjw8pZPRkAcoTVkwEAAACgdq6enK8yWT2Zb6kAkGPfj3ref2jDFv3Obf78+a6kpMTFWM7OFLKzjfzsIjvbyM8usrON/OwKakF2DE8GgByzvJpWXc9tzJgx5GcQ2dlGfnaRnW3kZxfZ2UZ+dsVrQXYUDQEAAAAAAAAkoGgIAAAAAAAAIAFFQwAAslRcXJzrTUCWyM428rOL7GwjP7vIzjbys6vYeHasngwABlatAgAAAABgRX4PpdMQAHLM8sS4dT23mTNnkp9BZGcb+dlFdraRn11kZxv52RWvBdlRNASAHKPh225uEyZMID+DyM428rOL7GwjP7vIzjbysyuoBdlRNAQAAAAAAACQgKIhAAAAAAAAgAQUDQEAyFJJSUmuNwFZIjvbyM8usrON/OwiO9vIz64S49mxejIA5AirJwMAAAAAViRWTwYAQyyvplXXc5syZQr5GUR2tpGfXWRnG/nZRXa2kZ9d8VqQHUVDAMgxGr7t5qZ/BJCfPWRnG/nZRXa2kZ9dZGcb+dkV1ILsKBoCAAAAAAAASMCchgCQ47kkDup+misK6ud6c5ChgqKYW3/vrm7EK3+5+DL+KrWE7GwjP7vIzjbys4vsbCO//PbkHzdWeFtpaakbOXKk69WrlyssLHT5gjkNAcASu1Nc1GlB3LkZ4+b6n7CF7GwjP7vIzjbys4vsbCM/u2KxmGvRooX/aRWdhgCQ49/wHNi5n6tX2CDXmwMAAAAAqKZOw3xFpyEAGBIrsPubp7qeW8cNVyE/g8jONvKzi+xsIz+7yM428rMrHo+78ePHs3oyAGA58ElsUqzAuZU7NfU/YQvZ2UZ+dpGdbeRnF9nZRn52BUHgZs2axerJAAAAAAAAAGoPioYAAAAAAAAAElA0BIBci9ttV6/LgnjgJv060/+ELWRnG/nZRXa2kZ9dZGcb+dkVi8Vc69atTa+eXJTrDQCAui7QvLiFud4KZJPb5N9m5XozkAWys4387CI728jPLrKzjfzsKigo8EVDy+g0BIAcixXa/c1TXVZQGHPd+rT1P2EL2dlGfnaRnW3kZxfZ2UZ+dpWWlrrRo0f7n1ZRNASAXOPvf5tizjVZtTH5WUR2tpGfXWRnG/nZRXa2kZ9p8+fPd5ZRNAQAAAAAAACQgKIhAAAAAAAAgAQUDQEg11gJzSStYPf391NZyc4gsrON/OwiO9vIzy6ys4387IrFYq5Dhw6sngwAyB6rJ9vNbca4ebneDGSB7GwjP7vIzjbys4vsbCM/26snt2zZ0llGpyEA5BirJ9ukFezW2rEjK9kZRHa2kZ9dZGcb+dlFdraRn12lpaXu999/Z/VkAMBy4O9/m2LOFTepT34WkZ1t5GcX2dlGfnaRnW3kZ9qiRYtyvQnLhaIhAAAAAAAAgAQUDQEAAAAAAAAkoGgIADkWlLISmkXx0sD9+fk//idsITvbyM8usrON/OwiO9vIz/ZCKJ07d/Y/rWL1ZADINf7+tylwbt7UhbneCmSD7GwjP7vIzjbys4vsbCM/s2KxmGvSpImzzG65EwBqiVgRsxpbVFAUc+vt1cX/hC1kZxv52UV2tpGfXWRnG/nZVVpa6kaOHMnqyQAA1EWF9fhr1Cqys4387CI728jPLrKzjfzsKjVcMBTOPAAAAAAAAAAJKBoCAAAAAAAASBALgoAp+AEgB+bNm+eaNm3qDuzSz9UraJDrzUGmYs4Vl9R3i+YvYTEba8jONvKzi+xsIz+7yM428strT/5xY4W3qdy2aNEiV1xc7BdFybfvoXPnzq1yoRY6DZFznTp1crfcckvZn/Vmevnll1fIa2+11VbuqaeeWu7n2WabbdxZZ51VLdsEmzbbbDP3wgsvZPdg/vK3KXBuycKl5GcR2dlGfnaRnW3kZxfZ2UZ+ptWvX99ZRtGwDjv66KN9gS68tGzZ0u2yyy7up59+yul2TZ482e266641/jqvvvqqmzp1qjv44IPL3Xb11Ve7wsJCd/311ztr9JuMfv36+TxXWmklt//++/v9zORc0EXnQrqPqVevnlt11VXdjjvu6B566CEXj8fLFYbD+zZu3NhtsMEGbujQoRnt1+DBg13Pnj3945s3b+522GEH9/XXX5fdPm7cOHfccce51Vdf3TVs2NB16dLFDRo0yC1ZsqTS541umzJv27atf57Zs2eX3WfhwoXuwgsv9M+p3xK1atXKbb311u6VV14pu88ll1ziLrjggnL7ng5WT7ZJK9itv3dXVrIziOxsIz+7yM428rOL7GwjP7vi8bhfPTmb74j5gqJhHafCkIp0unzwwQeuqKjI7bHHHjndptatW7sGDWp+qOZtt93mjjnmGFdQUP5toMLXeeed539a079/f/faa6/5otwnn3ziJk2a5Pbbb7+MzgVdnn766bQfo4LdW2+95bbddlt35pln+nNo2bJlCfcdMmSIv++IESPcxhtv7Pr27eu++OKLtPere/fu7o477vAfup9//rkv9u20005u+vTp/vbff//dfxjfe++97pdffnE333yzu+eee9xFF11U5XOH2zZ+/Hj35JNPuk8//dSdccYZZbeffPLJ7sUXX3S33367f523337bHXDAAW7mzJll91Ghe/78+f44AAAAAABgHUXDOk7FORXpdFlvvfV8p9SECRPKCjFy/vnn+4JNo0aNXOfOnd3AgQPd0qVLy27/8ccffbGopKTEj4ffcMMN3XfffVd2uwo8W265pe/+6tChgy/G/PvvvxVuU3R4sopR+rMKNnoNbcO6667rvvzyy4THZPoa2r8PP/zQ7bnnnuVuU6Htv//+84UkjfVPLmzpeY888kjfxdemTRt3443l5zB4/PHH3UYbbeSPiY7toYce6qZNm1Z2+8cff+z365133nHrr7++3+7tttvO30dFpzXWWMMfSz1OXW7p0pwEDz74oLvpppv88ymLhx9+2O/DV199lfa5oIu6+aoSPqZdu3a+e1AFOnXfaR8eeeSRhPuGx0Ln0p133un3WcXNdOlYqLtQ5+Baa63l91H5hJ2xKmBqX1VI1H322msvd8455/hzpyrhtmk/dJ4dddRRbvjw4Qldqdq33XbbzRcrdVxPP/10d+yxx5bdR12Kuv2ZZ55Je58AAAAAAMhXFA1RZsGCBe6JJ55wXbt29UNbowUVFYB+/fVXd+utt7r777/fd3GFDjvsMNe+fXv37bffuu+//94XHjVcVUaPHu2LORoiq+LOs88+6wt8p512WkbbdvHFF/sC0A8//OCLToccckhZJ1s2r6HbVYBUcS6Zim56fu2DfurPUeeee64vLKo49u677/oCYLTAJCqqXn755b6gqgKoip8azptqyK2651TUU7H2oIMO8vM7ap7FN954wz+/utvSpeOv11ZxLaQhvauttlq5Qmsy7ccqq6zievTo4U455ZSELrpMqFipwm5lxTp1tOr4VjV0uCJ63H333ecnb9VrVVZEbdGiRUbP/c8///hi5qabblp2nQqKb775pu8krMwmm2ziPvvsswpvX7x4sS90Ri8AAAAAAOSjolxvAHLr9ddf9x1zYQedOud0XXTIruZqC6nLSsU7dVNp+K5oSKcKaSpOSbdu3RLmBlRRMVwkRLdpWLDmg7v77rv9/HDp0Gvuvvvu/v8vu+wy32n2119/+dfM5jX+/vtvPwdf8tBkFXGef/75sgLb4Ycf7jsYVSzVcVJhVUVEFVe33357f59HH33UF02joh1o6nrT9mhIrh4fHm+54oorXO/evf3/ax49zZunIqgeIxoC+9FHH/luz3RMmTLFT7TarFmzhOu1r7qtIiq6agiz5gPU66urTsNtdRzUQZcp5VLR3Jgq+Kk7UwU9FRgzoXNTc1Cq+1Ln6nvvvedWXnnllPfV+aGC6w033FDl8+r46jwvLS31c0KqYKhOxpAKlDrHVExXkbJPnz4+mzC7kOZDVPFXw6RTDXvXuarzN1mwLHAu88OMHIsvC9yIV/7yP2EL2dlGfnaRnW3kZxfZ2UZ+dhUUFLhevXql/G5ohd0tR7XQUEx17+nyzTffuJ133tkXi1RUC6lzT8URdVup4KXiigqFoQEDBrjjjz/ed7ddc801vugUUqeduhT1uPCi11BRZezYsWlv5zrrrFP2/yoWSTjcN5vX0PDjVMVEzeOnxS7C7jUN2e7YsaM/BqJ9U9Er2oWmTjZ15yV3/Gnoszr81KmpAqZEj1vyfqmwFw4Bj14XHdZcU1SI03BefaDts88+vjinzlF1H2ZDS8snLymvwpyy0T5ee+21/lwJC8GZnq/qzFShU52ZqY6PugV1+4EHHuhOOOGEKp9XRW89rwqdmttTtG0qIoarbI8ZM8bfpmKh5kxUMVndpFEacq3zTh2FqagorGJpeFGB0WNOY5tiztVvVI/8LCI728jPLrKzjfzsIjvbyM+0JVmOrssXFA3rOK1Eq+HIuqgT7oEHHvAdhxqCLOo0U4eV5mpTIUmLWGiocPTE1xBbFVFUZNE8gWuuuaZ76aWX/G3qrDvppJPKCpO6qMj3559/+uJcusLhzhIWo8IViLJ5DXWnRVfHDamLUPui4bPhRcOyM1kQRcdPRUvNSahFNVR8C49H8gdG8n5F/xxel8lKSyrs6jXmzJmTcL1WT9Zt6VLhUsdI3XrZ+O2333zXYqrC3MSJE/2xT7d7MtX5utlmm/mslE/y8HEt/KLi4hZbbOE7BNOhfdXzqktV3Y8aIq7CpLo8Q8pGhUJtt4aNa85LFQ2jmc6aNctvo4qHFc0BqfMiepFYIf8CsKigMObW2rGj/wlbyM428rOL7GwjP7vIzjbysysej7tRo0aZXj2Z4ckoV6RS66w68USFE3XaqVAYinYhhjTPoC5auVfzAGpBin333dcvjqGimwoyNSWb19DiIxquq+JVuOCHVuXVAi7qrovOg6dC0DbbbONXzVURUsWjr7/+2ncRip7jjz/+KOsm1P00H6A66bQoi0QXhqlJWqBD26eOOM3xKPqQUofj5ptvnvbzqLCnfQi7OjOhwrGOpc6FVIW56pTc1acOQxUMwwVgsm0DD4dkh++DVFQc17yaGs6sIeHy888/+3MLAAAAAADrKBrWcSq4hHPdqfilRTnUuReuKqzOKxWcNIehOhG1OEfYNRcWVdRBpiGb6ixTsUmddWHBSl1Z6grToiQawqwuLBX4NBedXqs6ZPMaKuyoiDVs2DC3xx57+OvUsaaFLDQUNZn2Xbdff/31fu5B7bPmt9PCISqoRotTKiaqiKT59E4++WRfSEoexlpTtDCItk9DxlX4VCebVvlVwVDHKBTOBanCrvLWPHvKTN2IGoKt+SpV4FPHZDrnj4bxqpvx7bff9s+rY6oVpquLujevvPJKP4RahcwZM2b4FZhVJNQQZNH/q7irIrfmMYyuAF5Vl6UWONF+aFi1hgxr/1u1auW7FUXPq2K4VsRW7jq/NO+jCpRht6BoERSt3gwAAAAAgHUMT67jVORREUYXzdOngt/QoUN9kURUpFHHmApymt9PnYcDBw5M6MhSR5oKROo01BxzmhMxXOxBc/ZppWF14mlop4p1l156qV8worpk8xra7mOOOcYPHxYNMdXiJmGxM5muf+yxx/zKxCoc6nVUWNU8jloUQ51tIRWbNMeijqO60dRxmM5iHOnQ8ybPFZhMK1uraKdtVgFUBbPklYzVfag59cJjobn8lLUyVNFR+6MCmIbTpnP+aIEczSGo4bxa9EUrS2eygIq6O7VfWmU6FT2XOji1T9pGHXudd9pGLYojKhJrOLW6LLUwTXhep9MtqfNF99M5o2OnwrOGIIeriKt4qgVvVBDUitsqxOq65557ruw5VLTU+0PnFeqO0qV2hxrUdWRnG/nZRXa2kZ9dZGcb+dlVmMXCovkkFqi1BqiD1FmmgtPw4cN9d5oFgwYN8gXSbBcoyVcaSnzVVVf5Dr7keR2tUMerunXTnUcxXK1b3aEHdu7n6hVWXqAFAAAAAOSXJ/+40VkTfg9VI1F05FwqdBqizlIHnoYcJ69onM/eeustd91117na5s033/RFQ6sFQ9FQ9ayHoTOnsU0x55qs2oj8LCI728jPLrKzjfzsIjvbyM+sIAh8gc5yrx5FQ9Rp++yzjx9qbMU333zj512sbTSUO5yb0Kqzzz7brbrqqlk9ltWTbdIKdt36tGMlO4PIzjbys4vsbCM/u8jONvKzKx6PuzFjxphePZmiIQAAAAAAAIAEFA0BAAAAAAAAJKBoCAC5ZneKi7otcG7RvCXkZxHZ2UZ+dpGdbeRnF9nZRn6mFRcXO8tYPRkAcoTVkwEAAADAridZPRkAUJNifBKbzW3lTk3IzyCys4387CI728jPLrKzjfzsisfjbubMmSyEAgBYDgWshGZRrCDmOm64qv8JW8jONvKzi+xsIz+7yM428rMrCAI3YcIE/9MqioYAAAAAAAAAElA0BAAAAAAAAJCAoiEA5JrdbvW6LXBu3tR/yc8isrON/OwiO9vIzy6ys438TCspKXGWsXoyAOQIqycDAAAAgF1PsnoyAKAmsRKa3dzarNGC/AwiO9vIzy6ys4387CI728jPrng87qZMmcLqyQCA5cBKaCZpBbu2a7ZkJTuDyM428rOL7GwjP7vIzjbysysIAl80tDzAl6IhAAAAAAAAgAQUDQEAAAAAAAAkoGgIALlmd4qLOi2IOzdj3Fz/E7aQnW3kZxfZ2UZ+dpGdbeRnVywWcy1atPA/rWL1ZADIEVZPBgAAAAC7nmT1ZABATWJSY7u5ddxwFfIziOxsIz+7yM428rOL7GwjP7vi8bgbP348qycDAJYDn8QmxQqcW7lTU/8TtpCdbeRnF9nZRn52kZ1t5GdXEARu1qxZrJ4MAAAAAAAAoPagaAgAAAAAAAAgAUVDAMi1uN129bosiAdu0q8z/U/YQna2kZ9dZGcb+dlFdraRn12xWMy1bt3a9OrJRbneAACo6wLNi1uY661ANrlN/m1WrjcDWSA728jPLrKzjfzsIjvbyM+ugoICXzS0jKIhAOTYvd9d7po3b57rzUCGSktL3bhx41ynTp1cYSFVX0vIzjbys4vsbCM/u8jONvKzq7QWZMfwZAAAsjR//vxcbwKyRHa2kZ9dZGcb+dlFdraRn13zjWdH0RAAAAAAAABAAoqGAAAAAAAAABJQNASAHLO8mlZdz61Dhw7kZxDZ2UZ+dpGdbeRnF9nZRn52xWpBdrEgCFi3GwByYN68ea5p06Zu7ty5rkmTJrneHAAAAABALTcvg++hdBoCQB6sqgWbuf3+++/kZxDZ2UZ+dpGdbeRnF9nZRn52ldaC7CgaAgCQpUWLFuV6E5AlsrON/OwiO9vIzy6ys4387FpkPDuKhgAAAAAAAAASUDQEAAAAAAAAkICiIQDkWEEBH8VWc+vcuTP5GUR2tpGfXWRnG/nZRXa2kZ9dBbUgO1ZPBoAcYfVkAAAAAMCKxOrJAGCI5dW06npuI0eOJD+DyM428rOL7GwjP7vIzjbys6u0FmRH0RAAgCxZ/gdAXUd2tpGfXWRnG/nZRXa2kZ9dpcazo2gIAAAAAAAAIAFzGgJAjueSuHzzAa5BrH6uNwcZihXGXKvtO7npH4xzQSl/lVpCdraRn11kZxv52UV2tpFffjl32NUZD0/u1auXKywsdPmCOQ0BwBD+8reb28wvJpKfQWRnG/nZRXa2kZ9dZGcb+dlVUFDgevToYXr15KJsHvTnn3+6jz76yE2bNs3F4/GE2y699NLq2jYAAPJa/L9lud4EZInsbCM/u8jONvKzi+xsIz+76te3PaIs43Ln/fff79ZYYw1fHHz++efdSy+9VHZ5+eWXa2YrAaCWDzmA3aEi5GcP2dlGfnaRnW3kZxfZ2UZ+dsXjcT88ObnZrlZ3Gl5xxRXuyiuvdOeff37NbBEAAAAAAAAAW52Gs2fPdgceeGDNbA0AAAAAAAAAe0VDFQzffffdmtkaAAAAAAAAAPaGJ3ft2tUNHDjQffXVV37Z6Hr16iXcfsYZZ1Tn9gFAredXQstqWSrkOrfpH4xjJTuDyM428rOL7GwjP7vIzjbys6ugoMDXzerU6sn33XefW2mlldwnn3ziL1GxWIyiIQCgzihoWORKFyzN9WYgC2RnG/nZRXa2kZ9dZGcb+dm1ZMkSV1xc7KzKuNw5duzYCi9jxoypma0EgFqMldDs5tZyi/bkZxDZ2UZ+dpGdbeRnF9nZRn52xeNxN2rUKNOrJy9Xj2QQBP4CAAAAAAAAoPbIqmj42GOP+XHZDRs29Jd11lnHPf7449W/dQAAAAAAAADyf07Dm266yS+Ectppp7nevXv76z7//HN38sknuxkzZrj+/fvXxHYCAJB3gmV2hxrUdWRnG/nZRXa2kZ9dZGcb+dlVWFjoLIsFGY4vXn311d1ll13mjjzyyITrH330UTd48GA/tyEAoGrz5s1zTZs2dUM26e+KixrkenMAAAAAAJU4d9jVrrZ8D507d65r0qRJ9Q5Pnjx5sttiiy3KXa/rdBsAAHVF/ZYNc70JyBLZ2UZ+dpGdbeRnF9nZRn42BUHgC3SW1wLJuGjYtWtX99xzz5W7/tlnn3XdunWrru0CgDqDldDs5tZsw9bkZxDZ2UZ+dpGdbeRnF9nZRn52xeNxN2bMGNOrJ2c8p6GGJvft29d9+umnZXMaDhs2zH3wwQcpi4kAAAAAAAAAanmn4f777+++/vprt/LKK7uXX37ZX/T/33zzjdt3331rZisBAAAAAAAA5G+noWy44YbuiSeeqP6tAQDAkNJ/l+Z6E5AlsrON/OwiO9vIzy6ys4387CouLna1fvVkTdwYrqii/69MVSuvAAD+h9WTAQAAAMCOc1k9ubzmzZu7adOm+f9v1qyZ/3PyJbweAJAh5jS2KeZccbsS8rOI7GwjP7vIzjbys4vsbCM/s+LxuJs5c2btXwjlww8/dC1atPD//9FHH9X0NgFAnRIr4F8AVnNrstbKbvGUBS4orbJpH3mE7GwjP7vIzjbys4vsbCM/u4IgcBMmTPBNdrW6aLj11luX/f/qq6/uOnTo4GKxWMqDAQAAAAAAAKCOrZ6souH06dPLXT9r1ix/GwAAAAAAAIA6VjRUR2Fyl6EsWLDA/KowAABkYsnM/3K9CcgS2dlGfnaRnW3kZxfZ2UZ+dpWUlDjL0hqeLAMGDPA/VTAcOHCga9SoUdltpaWl7uuvv3brrbdezWwlANRifm6StD+NkU+5zfl+Sq43A1kgO9vIzy6ys4387CI728jPrsLCQtelSxdXJzoNR4wY4S/qNBw5cmTZn3X5/fff3brrruseeeQRlw+0HZlONHn00Ue7ffbZp8a2ybIHH3zQ7bTTTjnJJRtvv/22L2Cns0LRkiVLXNeuXd0XX3yx3K/bqVMnd8sttyz388AmnUs6B7777rvMH8w6KDbFnGvcpRn5WUR2tpGfXWRnG/nZRXa2kZ9Z8XjcTZkyxfTqyWkXDbVqsi5HHXWUe+utt8r+rMs777zj7r33XtetW7ca3diKCnsff/yx74CcM2eO/3Pfvn3dH3/84WqaimB6XV1UQW7evLnbdNNN3ZAhQ9zcuXOdJRUd20WLFvnO0kGDBpW7beLEia5+/fpu7bXXdvlkl112cfXq1XNPPvlklfe95557/FycW2yxRbnbTjrpJJ/r0KFDnTWaY/Swww5zTZo08YXa4447zk8hUJFx48aVncvJl8r2f5tttim7X4MGDVy7du3cnnvu6V588cVy940+Z9OmTV3v3r39yuyZUCb6TU3Dhg1dq1at3N577+1/aRH68ccf3SGHHOIXa9J91lhjDXfrrbdW+bzRbSsqKnKrrbaa765evHhx2X00l+spp5zib9O+tm7d2u28885u2LBh/na9F8455xx3/vnnZ7RP/vVZPdkk5da4S3PyM4jsbCM/u8jONvKzi+xsIz+7giDwRUP9rDNzGj788MO+EJHPVCxYZZVVVshr6VhMnjzZF9DUrXbiiSe6xx57zHe6TZo0qdKuJAuef/55v48q8KQqmh500EFu3rx5fnh6vhVBb7vttkrvozfuHXfc4QtqyRYuXOieeeYZd95557mHHnrIWaOC4S+//OLee+899/rrr7tPP/3Un5sVUZFN53H0ctlll7mVVlrJ7brrrpW+1gknnODvP3r0aPfCCy+4Nddc0x188MEpX0+fH7qvCm0rr7yy22OPPdyYMWPS3q8NN9zQP8dvv/3mf1mhDNUFqykS5Pvvv/fv/SeeeMLv/8UXX+wuvPBCn3NVwm0bO3asu+uuu9zjjz/urrjiirLb999/f99Z/eijj/pfSrz66qu+aDpz5syE4/7555/71wYAAAAAwLKMi4ai4XcqpqgwsN9++yVc8kGqYbD68q9igiahPP74490FF1yQcg7GG264wbVp08a1bNnS9evXzy1durTS11JnkjqO9Bh1NakApeKhurp0jEIqLpx22mnurLPO8sUSdSjJJ5984jbZZBPfuaTn0HYtW7as3ON0UXeWHqvOv2ilevbs2e7II4/0nY6aa1JFnj///LPs9sGDB5fbVw2j1VDK8HYVQl555ZWybit1b4oKZ+ocS6bXV5HliCOOcIceeqgfwpwqB3VlaZv23XffhOKKqMikTrFVV13VF6c23nhj9/777yfcR9uo7LR/uk/Hjh19sUZdX3qsrltnnXXKDQnVNus6vUZFVGDS7bvvvnu529Rdp+KX8lDBbcKECQm3T5s2zb+GCtTqVEzV1XjTTTe5Xr16ucaNG/ui3KmnnprQ7Reepyrq9ejRwx+nAw44wBcslYf2XZmeccYZZUWxdKigpiHaDzzwgO987dOnj7v99tt9lhUVstVRqfM4ennppZd8UVjHuDLabt2/ffv2brPNNnPXXnut7zy+//77y+Wp/dV91Z169913u//++88XNtOlQuRWW23lj80GG2zgzw1lo05JOfbYY31n4dZbb+06d+7sDj/8cHfMMcek7HxMFm6bslIxU+fX8OHD/W3qYv7ss8/8vm277bb+PNT7VgXJvfbaq+w5lJcK7DrWAAAAAADUqaKhvgxrKKcKEyoqqKimrhoNM1RRKx+poHPllVf6L/wqFKmQpYJFMg21VhFJP1W0UVEnm3kaVZxUx5GKW9Fij55TQxjVZaVhsf/884/bbbfdfLFMwyq1TSq+RbubwsdpyOQ333zjCyIqRqkgFO2qU4FMr/fll1/6gp6et6qCZ0hDKlUc0rDesMssHK6rrqmNNtoo5bFScWuHHXbwhRmdF//++2/Z7eo8VAFVxc4ffvjBF1qS90sFNG3nBx984Du49PoqxI0fPz7hfjfffLMvxOg+KvCpUKkiol5XRR0NV9Wfo4VUZaxipAo9FdFt3bt3T7makXLQ8+ucVhE2+TzQMVexSsdB3ZjqTFMhMaqgoMB3O+r9oQz1HokWkkXHUPfR8VOhT8VaFVjffPNNf1G3mwpweo106RxQASyam3LS9qTbEar3iXJL1YWZDk1joAJaZcU6FVyXp+tW55sK1yraqtBXEU0V0KJFi4yeW52EyktFV1HhVJeXX345YchyKiomVnTe6bHqzI1exHC3ep2m3P77Zz75GUR2tpGfXWRnG/nZRXa2kZ9dsVjMfxfVzzpTNLzqqqt8Eee1117zBTAVsTSnmIpOKtTUNHVlhV/gw0tVwyfVZaXihzqOVCS69NJLfQdYMhU5NIyxZ8+evtNIBSoVtLKh55g/f35Cd53mfLzuuut8V5kuKjSp2BG+puYU1JDQG2+8MWGiTN1Hx1yPUTHy9NNP938WdRSqWKgi4pZbbukXpFGRVAVJFTjSoWOoAk44T5suylbdVSq4tG3bNmVRTZ2m6lBT15i6uqJz3+m8UBFQRTIdc3XLhd2VIW2r5qjT43VsLr/8cl8A1P5EqbCo++k+yk6FFhVaDzzwQP/cmkNOReypU6cmPE7b/ffff1e437ot1b7pmH711Vd+bkxR8VDFqbAoqYKS5vVUJ5066zRkVsdDXXNR6ipVsVRdcdttt50vmj733HMJ91FhV8Xi9ddf33fQqdNQhVo9nzoddR7qOVScTJfmTEgenq+isz6sdFs69PrqnE0112M6VKBUNmEHYDIVSy+55BJ//qgrMBN634TvfeWgTkWdr6mo6/fZZ5+tdGh2SHMh6jmLi4v9e22ttdbynYTh8VPhWMVfFWRVxL7ooovcTz/9VO55Kjvvrr76al+IDi9lxc44/wIwKR64+b/MID+LyM428rOL7GwjP7vIzjbyM6ugoMDXyfTTqoy3PDqcU1/U1e2jqmn//v3dfffd52qaCijqgIpeol13qYwaNcp3/0Ql/1lUJFARI6ThwsndY+kKC0zRirKKS1EqdG2++eYJ91ExQh14miMxpMJU9D56jApb6mLUc6igEXZEiYZWq+ih25ZHWARTESVKxUR1kKmYFtL/R4co67Wj2xRud5T2U12OKk6pEKOCjR6X3Gmo4cchdQ9KtOgbXpeclQqhKk5Vtn/J+yaaw1AFTg0FD4uWKp6Gi3aExzyap4q+yUPiNTR3++2394uDqJtRHZIqIke3SUN7o0uwa19UZIwOCdZ12Z6H2dBxeeqpp7LuMoy+B5J/oxIW5nQ8NP+hzplovulQ4Vxdpxrar8KkfmGhBXuS/fzzz36IsRbxSWf1bxXi9Xmirl/9ckLFYWUWndNQw7tV1FZBXF2hGiKd3IVa2XmnIqTOpfBSNuydSY1tKoi5krVWJj+LyM428rOL7GwjP7vIzjbyMysej/v6Rp1YPTnajacOOlExRF/Mw0JSZQWa6qL54bp27Zpw0XZUB624G6WCR7bhqrCkBURUwItuey6oqp28Wk86Q5e17ToGmjMxSgUlFWlUFFTxTBd1+6lDLpNVq1Uw1BB3da9qOKcKNioGJg9XjeYSFqFSXZeclVYQ1gq7FVFRMHnfVIhVN9kbb7xRtm8q7Om5MlkQRR126hJUQUzFMQ33vfPOO/1t0f1Ldc4t73moTtHkIqPmydQ+6LaqaCi03ssa8p0tHUcVtjV0OFVhTh2PumgYc6bUoaeuU3VmalvV6azzKOrXX3/1BVt1GKqjMR06Nvo8UcFdvxhR16+6FP/666+y+6jIvOOOO/p5RdXFqGHqySuLV3beqZtXnwvRixjuVq/TlFvDdiXkZxDZ2UZ+dpGdbeRnF9nZRn52BUHgvx/WqdWT9UU9XLhAw0PPPPNMv3qqOoj0JT0fqQjw7bffJlyX/OfqpIKNCmsablxZG6o67MI5CEOa71BdWFpUIpQ8D52Gzqpooq5IPYcKQtH7qJtN3ZUa3ioqYCQv863CTZS6RpMX29B1eg4VYKLUHXb22WcndHuqO0vDo8PCmrYr1XZHaV9VdNEcfioWqmhT0XDWTKmoqa5YDfutiG5TwSl6XDSPoIri6mSL7t/TTz/tuytVHFdXoY65CoEhHW/dFtJtKvRpqLk6RdURV9lq2tVJHZ3aluj2qUtS25Pc/ZmK8tXiHpUVXKuiwqsKsurOS1WYW57njlJ2ukTnGdQckupIVkFSc5lmK+w6Th52HqX3R3QuT9EvUio77wAAAAAAsCDjoqHm39NcdnLxxRe7AQMG+LnkVBxItYJuPtAcgNo2FTLU/aS55TQXWXVMRqmChQpyWjxE3YUqmmkeOHVDXXPNNZU+Vqvpaniitk/FK61erK4lHdNosVHtrLpOhSkVrzRHo4q1ouKhhmCqcKtOPxXvNFRY3Ze6PlyBWasNaz5FFdLU8aa54KI0JFbHRK8xY8aMsk5EDdPV84ZUQNPiI1qBWnMRRi8qHOsYq6CmOQy1sIdWo9Yx13mjP0dp21WIC4uOWoW5utp2VaBUV1fykOgoFZY0RFpFppDOE3WZab7F6L5pCKyGH2u+SBWhNTxV8yyqMKrinI5HuLCHqDCmY6isxowZ4xc00eI3K4IKtto+nRNaPEfFWS1Io/dtOIej5rxU8VO3R6mrTqtFa3/Spa5EvQc0pF7HXV2nJ598sjvllFP8Ma4uOo6aE1DHW+8JdfrpFxc67hpCHhbs9Joajqz3TNjRqPO/Kiq06r4q7mro85AhQ3yxV8dThXjNS/nEE0/498nYsWP9HJ56T4Xvs5C6ZtMZDg0AAAAAQK0pGqoYpLm+wg4cFbYuuOACP8eXOqo0dDkfaQ40zSWm4bCag0xf+NXhlmo+u0xpUQ7NfaginQpUWulWHU7qVNP1ldFj1Nmmwo2KVCq0aB655OGUGiaqbifNw9ivXz9fMIwu7KBFOjS/nobDahtUyNTzhsNcVfTQ4hEqFup19Ho6FlEqMKkYphV31QWmQpNoe/Rcmn9NwgU6VHBKpo5BdVnq/uqu00IhWhBFr/nuu++W2y+tAq1zRkVWrZqsAqXyqQ4qrip3DS2ubPi1tlmFQFHxW8OSk7vjwnNd9w0L4zrmKsBpEY/99tvP5xFdfET7rP3Tit0qOuo1VPCqDoMHD/ZF3sro9ZSRun9VUOvTp0/CnKMqaKpAnDylgIre6nLNpOilnHWua25GHQt1pmpYr865TGhuwMoK+Xq/qiCn/VFRVgvVqCtXxcPw2Gu4sgqEKu5pm8KLFs6pihZK0n21/yqAa45TFdc1RF3zMKpLU8Or1W2tTDVEWe8bFcRD6hzWe0UL2mQiYFJjk5Tbv6Nnk59BZGcb+dlFdraRn11kZxv52RWLxfxoO8urJ8eCDAdXqwijjrqOHTs6yzQvmcJTB1g+U5fgeuut52655ZacbYO6uVTMC1eSzXfqlFQB9Lvvvis3p14ydY3pXFAHZnTxkXymorQ+dJIX4LBOXbbq8NMCI1apkKmCsVZWTveXDupKHrJJf1dc1KDGtw8AAAAAkL1zh1VPM1Auhd9D1fASzrNfbcOT1e2WPB9evlM3lbq+NAxVw4BVnNDKttkswlAXXX/99WYKaqJ5EdXlVlXBULRQiboB1X1qgWr8KqpdfvnlrrZRV5+G+1qlBW40N6dWks9UrNDub57qMuXWbMPW5GcQ2dlGfnaRnW3kZxfZ2UZ+dpWWlvoGpeT1IywpyvQBmodPc4VpLj4NiU1eEVhFmHyjriwNmdWiCFogQ11oWtF2hx12yPWmmaChsJp30QoNsdYlXRqqboXO5b///tvVRsnzK1qjhYPSXakZtUf9lv9/LlPYQna2kZ9dZGcb+dlFdraRn13z5893lmVcNAwXQdFCF9FChjqg9DMfK6haKEGdhRZZHqoJAAAAAACAOlI0tDKMEwAAAAAAAMAKKhpaXwAFAPKNXwntf4vSw1hu836ZwUp2BpGdbeRnF9nZRn52kZ1t5GdXLBZzHTp0ML16csZFw8cee6zS24888sjl2R4AqHv4+9+mwLlF/9ieo6TOIjvbyM8usrON/OwiO9vIz6yCggLXsmVLZ1nGRcMzzzwz4c9Lly71qxNrEYBGjRpRNASADLESmt3cWmzWzs366h8XlFL5tYTsbCM/u8jONvKzi+xsIz+7SktL3Z9//um6devmCgttDi0ryPQBs2fPTrgsWLDAjRo1yvXp08c9/fTTNbOVAADkocLG9XK9CcgS2dlGfnaRnW3kZxfZ2UZ+di1atMhZlnHRMBVVTa+55ppyXYgAAAAAAAAA6mjRUIqKitykSZOq6+kAAAAAAAAAWJnT8NVXX034cxAEbvLkye6OO+5wvXv3rs5tA4A6wc9NkvGnMfIhtznfT2FuGYPIzjbys4vsbCM/u8jONvKzvRBK586d/U+rMv6aus8++yT8WUtHt2rVym233XbuxhtvrM5tAwAgry2Z+V+uNwFZIjvbyM8usrON/OwiO9vIz6ZYLOaaNGniLMu43BmPxxMuWg1mypQp7qmnnnJt2rSpma0EgFqM1ZPt5tZqu47kZxDZ2UZ+dpGdbeRnF9nZRn52lZaWupEjR/qfVtntkQQAIMdiRfw1ahXZ2UZ+dpGdbeRnF9nZRn52lRouGGY1PHnAgAEVtl0WFxe7rl27ur333tu1aNGiOrYPAAAAAAAAQL4XDUeMGOGGDx/uq6U9evTw1/3xxx+usLDQ9ezZ0911113u7LPPdp9//rlbc801a2KbAQAAAAAAANSgjHtc1UW4ww47uEmTJrnvv//eXyZOnOh23HFHd8ghh7h//vnHbbXVVq5///41s8UAUMuwEprd3GZ+MZH8DCI728jPLrKzjfzsIjvbyM+ugoIC32xnefXkWBAEGZ157dq1c++99165LsJffvnF7bTTTr5oqE5E/f+MGTOqe3sBoNaYN2+ea9q0qRuySX9XXNQg15uDLGhCav4BZxPZ2UZ+dpGdbeRnF9nZRn7549xhV6d9X5XbtICwioaa0i/fvofOnTu3ytWdMy536kmnTZtW7vrp06f7F5ZmzZq5JUuWZPrUAFAnsRKa4ZXstu9EfgaRnW3kZxfZ2UZ+dpGdbeRnVzwe96sn62edGp587LHHupdeeskPS9ZF/3/ccce5ffbZx9/nm2++cd27d6+J7QUAAAAAAACQbwuh3HvvvX6+woMPPtgtW7bsf09SVOSOOuood/PNN/s/a0GUBx54oPq3FgAAAAAAAED+FQ1XWmkld//99/sC4ZgxY/x1nTt39teH1ltvverdSgAAAAAAAAD5uxAKAKB6sBCKfUxKbRfZ2UZ+dpGdbeRnF9nZRn7549w6thBKWp2G++23n3vkkUf8k+n/K/Piiy9mtrUAABhV0LDIlS5YmuvNQBbIzjbys4vsbCM/u8jONvKza8mSJa64uNhZlVbRUBXIsCqqwmE+VUgBwLrT3h7omjdvnuvNQIZKS0v9ami9evVyhYWFud4cZIDsbCM/u8jONvKzi+xsIz+74vG4GzVqlOns0ioa7rvvvmWVUXUcAgAAAAAAAKi9CtItGs6ZM8f/v6qj06ZNq+ntAgAAAAAAAJDPRcNWrVq5r776qmwiR4YnAwDwv1+kwSays4387CI728jPLrKzjfzsKjSeXVqrJw8ePNgNGTIkrWKhxtsDAKp31SoAAAAAAPJu9WQVDQ8++GD3119/ub322ss9/PDDrlmzZsu9oQCA/3Vww2Zu8+fPdyUlJXTgG0N2tpGfXWRnG/nZRXa2kZ9dQS3ILq2iofTs2dNfBg0a5A488EDXqFGjmt0yAKhDq2rBZm5jxowxvRpaXUV2tpGfXWRnG/nZRXa2kZ9d8VqQXdpFw5CKhgAAAAAAAADq+EIoUVOnTnVHHHGEa9u2rSsqKvLV0ugFAAAAAAAAgG0ZdxoeffTRbvz48W7gwIGuTZs2ZsdlAwCwvIqLi3O9CcgS2dlGfnaRnW3kZxfZ2UZ+dhUbzy6t1ZOjNIHjZ5995tZbb72a2yoAqANYPRkAAAAAkK/fQzMentyhQwdW+gSAasRCKHZzmzlzJvkZRHa2kZ9dZGcb+dlFdraRn13xWpBdxkXDW265xV1wwQVu3LhxNbNFAFDH8IsYu7lNmDCB/AwiO9vIzy6ys4387CI728jPrqAWZJfxnIZ9+/Z1CxcudF26dHGNGjVy9erVS7h91qxZ1bl9AAAAAAAAAPK9aKhOQwAAAAAAAAC1V8YLoQAAqncC2jf2O9OtVFg/15uDDAUFMbe4W2vX4M8pLhbnr1JLyM428rOL7GwjP7vIzjbyy42tnrtuuZ+jtLTUT+3XqVMnV1hY6CwuhJJxp2G44y+//LL77bff/J/XWmstt9dee+XVQQAAK/xf/nx8msyteNTkXG8GskB2tpGfXWRnG/nZRXa2kZ9dhYWFfmo/yzJeCOWvv/5ya6yxhjvyyCPdiy++6C+HH364LxyOHj26ZrYSAGqxIJbrLUC2uS1p15z8DCI728jPLrKzjfzsIjvbyM+ueDzupkyZUrdWTz7jjDN8pVQrwAwfPtxfxo8f71ZffXV/GwAgQzH+BWBSLOaWtmtBfhaRnW3kZxfZ2UZ+dpGdbeRnVhAEvmhoeVbAjIcnf/LJJ+6rr75yLVq0KLuuZcuW7pprrnG9e/eu7u0DAAAAAAAAkO+dhg0aNHDz588vd/2CBQtc/fpM5A8AAAAAAADUuaLhHnvs4U488UT39ddf+xZLXdR5ePLJJ/vFUAAAGbLbrV63Bc4VTZ9HfhaRnW3kZxfZ2UZ+dpGdbeRnViwW86N09bPOFA1vu+02P6fh5ptv7oqLi/1Fw5K7du3qbr311prZSgCoxWKG57io67k1GDud/AwiO9vIzy6ys4387CI728jProKCArfaaqv5n3VmTsNmzZq5V155xa+i/Ntvv/nrtJqyioYAgMwFhn/zVNdzW9JpZVd/3Az+EWcM2dlGfnaRnW3kZxfZ2UZ+dsXjcTdx4kTXvn17s4XDjLZ63rx5ZUtFq0i45557+kvnzp39bQCALFAztCnm3LJWTcjPIrKzjfzsIjvbyM8usrON/MwKgsDNmjXL9OrJaRcNX3rpJbfRRhu5RYsWlbvtv//+cxtvvLF77bXXqnv7AAAAAAAAAORr0fDuu+925513nmvUqFG52xo3buzOP/98d8cdd1T39gEAAAAAAADI16Lhzz//7LbZZpsKb99qq63cyJEjq2u7AKDuMNyuXqcFgav3zyzys4jsbCM/u8jONvKzi+xsIz+zYrGYa926tenVk9NeCGX27Nlu2bJlFd6+dOlSfx8AQGZi/P1vNrf6//D3nkVkZxv52UV2tpGfXWRnG/nZVVBQ4IuGdaLTsFOnTu67776r8Hbd1rFjx+raLgCoM4ICu795quu5LerRhvwMIjvbyM8usrON/OwiO9vIz67S0lI3evRo/9OqtIuG++23n7v44ovd1KlTy902ZcoUd8kll7j999+/urcPAIC8Vdq0/Dy/sIHsbCM/u8jONvKzi+xsIz+75s+f7yxLe3jyBRdc4F555RXXrVs3d/jhh7sePXr463///Xf35JNPug4dOvj7AAAAAAAAAHB1o2hYUlLihg0b5i688EL37LPPls1f2KxZM19EvPLKK/19AAAAAAAAANSRoqE0bdrU3XXXXe7OO+90M2bMcEEQuFatWpleCQYAco6V0GwKAtdg7DTys4jsbCM/u8jONvKzi+xsIz+zYrGYH5VruWaWUdEwpB1WsRAAsPxYPdlubkXTbc9RUleRnW3kZxfZ2UZ+dpGdbeRne/Xkli1bOsvSXggFAFAzWAnNbm7/9epAfgaRnW3kZxfZ2UZ+dpGdbeRnV2lpqV8HpE6sngwAABLFG9bP9SYgS2RnG/nZRXa2kZ9dZGcb+dm1aNEiZxlFQwAAAAAAAAAJKBoCAAAAAAAAyHwhlNtuu82l64wzzkj7vgAAjTcInCvM9UYgY/HAFY+a9L/8YAvZ2UZ+dpGdbeRnF9nZRn6mF0Lp3Lmz/1mri4Y333xz2qsqUzQEgMwwpbHd3Arn/pfrzUAWyM428rOL7GwjP7vIzjbysysWi7kmTZo4y9Iqd44dOzaty5gxY2p+i5HSNtts484666wq7/fBBx+4NdZYw/TqPdXh7bffduutt56Lx+NV3nfJkiWua9eu7osvvlgh2wabDj74YHfjjTdm9VhWQrNJuS3ccHXyM4jsbCM/u8jONvKzi+xsIz+7SktL3ciRI03XX7LukVQhZdSoUW7ZsmWuphx99NFun332cZaqyOGlqKjIrbbaam7AgAFu8eLFGT1Pp06d3C233FIj23jeeee5Sy65xBUW/m8s5COPPFK2zWqZbdOmjevbt68bP358uaKk7nPNNdeUe87dd9/d3zZ48OCy61REPvTQQ13btm1dcXGxa9++vdt77739cuP5YJdddnH16tVzTz75ZJX3veeee9zqq6/utthii5RZ6zcHG2+8sXvllVcSHhceWxVpkw0dOtTfpqxD+iDR8e3Zs6dr2LCha9Gihdt0003dAw88kPHqTP369XMtW7Z0K620ktt///3d1KlTq3yvRfdJFx2jdB+jY7nqqqu6HXfc0T300EPlirHaz/C+jRs3dhtssIE/Bpn67bff3F577eWaNm3qn0fHPflclSAI3K677upf7+WXX670OcNzO7xoPw488ED3999/Z5SN3ldXXnmlmzt3bsb7BbuCQrtDDeo6srON/OwiO9vIzy6ys4387Co1XDCUjM+8hQsXuuOOO841atTIrbXWWmVf2E8//fSUBaV8CyudzrLl8fDDD7vJkyf7otldd93lHn/8cXfFFVe4fPD555+70aNH+yJSlIpe2uZ//vnHvfDCC74YrKJJsg4dOvhCWJQeo+5FFRtDS5cu9cUjFU9efPFF/3zPPvus69Wrl5szZ07W269CUHUWqVX0qmq+Tr3mHXfc4c/5irL+7rvvXO/evd0BBxzgf4sQpcLWtGnT3Jdffplw/YMPPuiLylGXXXaZnwrg8ssvd7/++qv76KOP3IknnpjxMevfv7977bXXfFHuk08+cZMmTXL77bdflY9TkVD7E16efvrptB8zbtw499Zbb7ltt93WnXnmmW6PPfYol9WQIUP8fUeMGOGLfSpOZ9K9qXO3T58+vnD38ccfu59++skNHDjQF6WTqeiuAmC6TjjhBL9tOlYq/k6YMMEdfvjhGWWz9tpruy5durgnnngi7dcFAAAAAKDWFA0vvPBC9+OPP/ov7dEv6zvssIMvDK1IN910ky9EqTCjgtapp57qFixYUHa7ClzNmjVzr776qltzzTVdgwYNfJFTxQF1x6ljSB1kTz31VLnuPhUDjj/+eNeqVStfVNtuu+38fldFr9e6dWu/PSqcqLtu+PDhCYUPXaduJnWBqXjy/vvvJ3Q9qcNJhZ+w8yk0bNgwf7sKts2bN3c777yzmz17dtntKoiqk1BdUNqGaOefPPPMM76Yl1xk0Wvo/ir8qZtOBbJvvvnGzZs3L+F+2p8ZM2b47Qg9+uijbqeddnKrrLJK2XW//PKL308VTTfbbDPXsWNHX1RT8VR/FhWZ9LraJr2mtklFFxW5QjrHdB8VozbccEOfnwqf6tzU3Jl6TT1OhaRvv/223OPeeOMNt8466/j76HV//vnnhP3Zc889fcFP21qR77//3t+u86WirLt37+6LSSqSqZgUpY5TdVyq+y40ceJEv426Pkrnqc5hFWx1Xq677ro+i3POOcelS4VaFST13tA5q+Om4qaKc1999VWlj9Xx1f6EF51jVQkf065dO989eNFFF/mimzJLLjCXlJSUHa8777zTv/9U3EzXxRdf7HbbbTd33XXXufXXX98X6NR1GD335IcffvDDhKPHvCp6T4XvAZ0rp512WsL7Nt1sdE7pnAYAAAAAoM4VDTXUT51XKtREC1rqOqys+FITNJxWnWIqUql49eGHH/qiWXJn5LXXXuuHEep+KjAceeSRvqNIhRt11t13332+GyxKxQFdp+KHCkcqiGy//fZu1qxZaW/fH3/84bdJwxhDKmqq8KHuPHVcqVNLhYawY1OdeRrKG3Zl6RIWQvT6Kn6qa03FMz0u2uqqY6AC6tdff+0LK3qO9957r+z2zz77zG200UaVbrP2+aWXXvLDl8MhzKH69eu7ww47zBehQioMHXvssQn3U6FV2Tz//PNVtuKee+657uyzz/bHYvPNN/f7NHPmzIT7XHDBBb6LVUNTVQRUxspN+6vCjuYbVAE1ORs9t4pHKihqm/Tc6oIMqdNPxVsdl4roNhW5VPCqiIqFKtSFxyiZjs9zzz3nz8XwmCl3vXaUilY6X6ZPn+6ypXNV+6gifkidedrX5G7HZHo/6P3Ro0cPd8opp5TLIV0qVqqopnO5IiqmakizpjlIhwriKgIrC2Wt7dT7KnnosY6xirEqSup4ZkPnkfKKvm/TzWaTTTbxBfeKpiTQ9SrGRy//20FWQjMpHriGIyeQn0VkZxv52UV2tpGfXWRnG/mZVVBQ4L9fW149OeMt15fm5M4e+ffffzMaDlgdtPCHhkOqS1CFCnWy6ct+lAoo6nhTN5vCUnFOnX3333+/LwqoGKiC4n///f/ViFSQ0xd/De9Uka1bt27uhhtu8J1lKoRV5pBDDvEdhOpu0+upmKruzJCKKSeddJLvqtPzqkNNHVPqZBJ1CapYF3ZlhYUPFQG1LdoXPYeeV91QK6+8ctlzq6A2aNAg/7wqjOr+Kk6G1MGoOQZTdadpm1VwVCFL3XKaE09/rqgAprw//fRT/1h1IEap60zF3EsvvdR3qykb7WeqhXK0DxourXn/7r77bj9XXViAC6n4qQ5JHSd1tul+119/vZ+zTkVUZamuteTH6VjocepGVYFR8/qpIBql4xGduy5ZRccsmrW2SZ2hOg8POuigcvdTV5yWWde5o+HOqQqtou5Avb+UubI8+eSTfdE6E1OmTPGFS52rUcpVt1VERczHHnvMny8qsqvjU8c32/kXVKhUN2kqKhReffXV/tzRuZEOFbNVcFfxWNv67rvvun333dcPu452pyoHvdfVzZsJva/C94DmgtSQ+minYrrZ6FzR/lV0rLXfOsfDizqSYVts8f//RQRsITvbyM8usrON/OwiO9vIz676KRqLanXRUIUodfyEwkKhCm/qFFuRVPxT952KVCqyHXHEEb47KuzoCgPSl/yQigHqclKxMKROtehQTA1DVoEiXEgivGiewqq6KTXvmboC9Ryvv/667zbUdoX0vBrSqCKZCjt6XnXQpVrMISrsNKxMdD9FQy2jHZQqjKaa/03HTs+vobrqzNOx0YIOqahgqaKkCmAqqmjfdDyTqeiowokWGtF5oQKsCp3RzkeJnjN6Hp1fOh5R0e5IHX8VgjXcOaSONXV4JT8u+twqxqqIm3wfFRuj50uyio5ZNGsVj1S81HtAr5OKioTq0FSBSwVXdZsm03NoCLWGEev+yk7dkRomvyJW/tVQXxVYtfiQzl11aKr7MBsqjib/EuH888/357uGAqswqQJgqmHfqYRzkaoYqMKgVr5WB6oK1lqoRlR4VzdgNosIqYM2fN/qlwb6TNCw+/nz52eUjc4nqeic0i8QVCwNL5o70WMlNJu0kt1GncnPIrKzjfzsIjvbyM8usrON/MyKx+N+3YOaXlujJpWv9lThqquu8h1IWgxAwzJvvfVW//+aMy3a8VPT1MWkgoGGUarApWKNvuxrnjF1+qgwEX6Jz7QDUoU9FdxSFUySO7iSqRNJBQdRkUpFB3WkqQtS16tgqMKZOhf1Z22fFtCoaphmWIyojIpnUdrv6MmprsToHIghtcqG26xipgpzOq5axCUVFU00/FO5qyOzIipGqrCii/Zfw0r1U91/mUjV8VhdNBRVQ5cromOWvLhJcta6qCCoQqCOSapOXBWlNKxa80xWVGgNs9A8l7qok1aLauj+ms9Pc+lVRdukc0lzckbPVXVZZjJcV52R2ve//vqrymJ1KirOJm+vhotr8RkVDtX5mMn7UtuiY6biXZTOV73vRQVDnbvJ71F1sm655ZaVFkDV9Re+B/RTXav6DNA8rWFhMJ1swiHyFZ1T6krVBQAAAACAWtdpqLkM1ZGjgqG6kjRMUEUSzZemRRdWFM3dpoKYOuO0cIHmOtM8hVVRIU/brjn0QiqMRItp6rRTl5yKFGFRKLxEhwOnI5wXMBz+rEVEVDjR0EodPxVykodxqjsyeViougijQ42zoWGyKmpVRR1cKpZEF4KI0pxxKqRpiHVyEaciKhBpyKq67KKii3MoF+WqQlBFNERZxye6GIs6D9UVl7wt0edWvur6jD73okWLfJFJx6Uiuu3333/3nXOVUaejzv+KOjRV1FYnnwrrqYYmVyTcp+TjVhFtg4rH0XNF3bXqZM2kE1iLtahrN7oqdrpUvNP5kbxKt947eg/pnM+0kK/MVazTvkQpUy20E563WlFZn0/hJewIjc7Dmc37Nt1s1I2oOUkz/ZwAAAAAAMB8p2FYuNE8ciuChvCFX/5DGjas4oOKRbfffrvvZFMRKRymWBkVrrRIxIknnujnxlOBRQtxRDsSdbsKLBqmqbkEw4KkhmWr2FfZYiLq8FLBUQXNP//808/Hp8eHxSoN7dUCEdpmvd7AgQPLtapqbjzNF6gho+pKUgFCwxpVZNQKrppPTUUUzT2oBVvSLVCo009z+1VF86xpPzUnoYapJtNQbi3QktzZGFJemk9QXVgqrGhbVSzTcGYNUY1Sx6KOiY6Pijsq7lVWVFPXobog1bWmQpwW+FBGGg6qLtMoHXudK+pqUzeYjpMyjRYVdXwrK6Zpzkx1nmoRHRVJK6PuMx03dRRqyHwyzWWoufO0Tamo41TDrjUnnwprGg6v3HX+6LxNhzrmdBwGDBjgj49W/j799NP9PoYrV4ueT/PraXu1f5dddpkv8ul1VUjVPoQLzFRGC3vofFeRW92Mb7/9tn9edQFrXs3qpMz79u3rttpqK5+LXkurL4cdhNE5QKN0jlTVpanzJ5yHUPuhOTg1LF1DlDPJRgvnhI8BAAAAAKDWdxomr/ZZ2aW6qSCgbq/oRQUOza2nxQk0N5qKOZo7T8WKdGjBBxWSVHxQ0eSEE07wQ2nDuetUzHvzzTf97cccc4wvDKiAp0Uxkle8Tab7qztL3UYalqx5/DTnXTgcVdusopuKDyocqigTnV8xLHap+1DF2XCYo7ZBXZ2ac01dbSoCvfLKKxUOc01FQ2RV/Eru1kpF88apSFrR8GMNAa1o2LD2XYVP5RQuNqNh7PqzindRmtdOF+WpYaaal66qIqjurwKXipJ6bnWKvvPOOwnzUob3O/PMM333nQpCKjBFJyF9+umn/TEJh7KnogKfzhGdX1XRAh0qTlXUbajCdEUFQ9G5oG3UeaG8jzrqKF+QUu5hzio8VtWlp+KrinY6RjqHVeRKXslY54AK8mFXnTr01Amp11XRUcdMBbCqhtKqcKfzXXlr/1XI1iI4OjeTV9+u6n2u/apo8RRRDvrFgIrEKqBrDkmtoq3u5+WlX4JoP3RRQXLGjBn+M0Cdyelmo85Vreasz5OMsRKaTfHANfpuDPlZRHa2kZ9dZGcb+dlFdraRn1kFBQX+u6vl1ZNjQVXjLv9vR9MdTpjtaqu5pKGY6q4LF1apzdStpeLuvffem9PtUHFIBTYNE9eiFtVJBSgVftS1WNEclCoKqSCkxV+q6kJTQU3zMKoDT/Px5ZI6ONW1me0CJflKw4c1X6qGz1fUwZrv1Lms1blVSEyX3ovqDn1jnzPcSvWY69Aa/eUZNKzvYv8tcUxLbQvZ2UZ+dpGdbeRnF9nZRn65sdVz1y33c6jcpuYSNahlOkVXTQq/h6qRSKMTK5NWuVPdQ5qnTBcNMdUchhq+qC/Iuuj/1YGn2yzQfqijTUMMtYCLugjVKaWurNpOnX6aA87y6j3VVbTUUOF0FhfRfJLqaNX5kmvqWlWnXW2jrj4VDa0WDEXbrukSssJKaDYVxNx/vTqQn0VkZxv52UV2tpGfXWRnG/mZFY/H/Sg/y/WXtMa2br311glDZzXEVkNvQxrWqJbL++67zw/by3eaC/Giiy5yY8aM8cOSNVRYw08tFyzSpc477Xtdp3kpK5ubMpkWr8kHla1WbdnQoUOddeEqywAAAAAA1MmFULRKcqoFR1SAsfKlWfOTVbXAA2qWOjvTGBmflW222abGnhsAAAAAAKAuyHg2Rs39l2rlZC1KoNsAAKgrYqV2hxrUdWRnG/nZRXa2kZ9dZGcb+dlVmMECoWYXQkmee0yrsnbt2tWvjBsOmfzzzz/9Sqa77bZbTW0rANQq4QS0b+5zhmvMQigAAAAAUGsWQslX1b4QSpSKgioQ7rnnnm7WrFn+ov//448/KBgCQBYYTG83t9KmDcnPILKzjfzsIjvbyM8usrON/OwKgsAX6CxPn5bxnIbSvn17v9IpAKAasBKaTQUxt6hHW9fouzHOxe3+Q6BOIjvbyM8usrON/OwiO9vIz6x4PO4X4NXCwVaHKWdVNJwzZ4578MEH3W+//eb/vNZaa7ljjz3WtzcCAAAAAAAAsC3j4cnfffed69Kli7v55pvLhiffdNNN/rrhw4fXzFYCAAAAAAAAyN9Ow/79+7u99trLr6BcVPS/hy9btswdf/zx7qyzznKffvppTWwnAAB5p+C/JbneBGSJ7GwjP7vIzjbys4vsbCM/u4qLi12dWj25YcOGbsSIEa5nz54J1//6669uo402cgsXLqzubQSAWonVkwEAAAAg/7B6cpbDk/WE48ePL3f9hAkTXElJSaZPBwB1XsA6KGZzW9aqhPwMIjvbyM8usrON/OwiO9vIz/ZCKDNnzvQ/rcq4aNi3b1933HHHuWeffdYXCnV55pln/PDkQw45pGa2EgBqsxj/AjApFnOLV1+F/CwiO9vIzy6ys4387CI728jPrCAIfM0swwG+tuc0vOGGG1wsFnNHHnmkn8tQ6tWr50455RR3zTXX1MQ2AgAAAAAAAMjnomH9+vXdrbfe6q6++mo3evRof51WTm7UqFFNbB8AAAAAAACAfC8ahlQk7NWrV/VuDQAAhhTOZfEvq8jONvKzi+xsIz+7yM428rOrxPjaH2kXDY899ti07vfQQw8tz/YAQJ0TiwfOFeZ6K5BNbsWjJud6M5AFsrON/OwiO9vIzy6ys4387CosLPQjcy1LeyGURx55xH300Uduzpw5bvbs2RVeAACZYSU0u7ktadec/AwiO9vIzy6ys4387CI728jPrng87qZMmWJ69eS0Ow210MnTTz/txo4d64455hh3+OGHuxYtWtTs1gFAXcBKaDbFYm5puxau3uQ5Whot11uDTJCdbeRnF9nZRn52kZ1t5GdWEAS+aNiqVStX6zsN77zzTjd58mR33nnnuddee8116NDBHXTQQe6dd94xvXw0AAAAAAAAgCyLhtKgQQN3yCGHuPfee8/9+uuvbq211nKnnnqq69Spk1uwYEEmTwUAAAAAAACgNhQNEx5YUOBisZjvMiwtLa3erQKAuoRmbZsC54qmzyM/i8jONvKzi+xsIz+7yM428jMrFov5af30s04UDRcvXuznNdxxxx1d9+7d3ciRI90dd9zhxo8f71ZaaaWa20oAqMViTPFgNrcGY6eTn0FkZxv52UV2tpGfXWRnG/nZVVBQ4FZbbTX/06q0t1zDkNu0aeOuueYat8cee7gJEya4oUOHut122830AQCAXAsM/+aprue2ePVW5GcQ2dlGfnaRnW3kZxfZ2UZ+dsXjcd9kZ3n15FiQ5iomYYV0/fXXr7S18sUXX6zO7QOAWmvevHmuadOmbtasWa558+a53hxkSFNzqOO+V69errCwMNebgwyQnW3kZxfZ2UZ+dpGdbeRnV2meZhd+D507d65r0qRJpfctSvdJjzzySNPjsAEAAAAAAACkJ+2i4SOPPJLuXQEAAAAAAAAYxmSEAJBjdHHbza1169bkZxDZ2UZ+dpGdbeRnF9nZRn52xWpBdmnPaQgAyN1cEgAAAAAArMjvoXQaAkAeTJALm7mNHj2a/AwiO9vIzy6ys4387CI728jPrtJakB1FQwAAsjR//vxcbwKyRHa2kZ9dZGcb+dlFdraRn13zjWdH0RAAAAAAAABAAoqGAAAAAAAAABJQNASAHLO8mlZdz61Dhw7kZxDZ2UZ+dpGdbeRnF9nZRn52xWpBdqyeDAA5wurJAAAAAIAVidWTAcAQy6tp1fXcfv/9d/IziOxsIz+7yM428rOL7GwjP7tKa0F2FA0BAMjSokWLcr0JyBLZ2UZ+dpGdbeRnF9nZRn52LTKeHUVDAAAAAAAAAAkoGgIAAAAAAABIwEIoAJDjCWh/u/gU16S4Qa43BxnSX56LGjRyxYsXOrvrodVNZGcb+dlFdraRn11kZxv51Zy2l9xco88fBIGbP3++KykpyasVlDNZCKVohW0VACCl/PnrA5nm1nDxwlxvBrJAdraRn11kZxv52UV2tpGfXbFYrMqiXL5jeDIA5Fg8xkex1dz+btOV/AwiO9vIzy6ys4387CI728jPrtLSUjdy5EhWTwYAoC4K+MebWWRnG/nZRXa2kZ9dZGcb+dlVarhgKJx5AAAAAAAAABJQNAQAAAAAAACQgKIhAORYLIjnehOQZW5tp40jP4PIzjbys4vsbCM/u8jONvKzq6CgwPXo0cP/tMrulgMAkGNFpctyvQnIEtnZRn52kZ1t5GcX2dlGfnbVr1/fWUbREAByjImN7eY2vk1X8jOI7GwjP7vIzjbys4vsbCM/u+LxuF89WT+t4qwDAAAAAAAAkICiIQAAAAAAAIAEFA0BAAAAAAAAJKBoCAA5xkpodnNbbfJf5GcQ2dlGfnaRnW3kZxfZ2UZ+dhUUFLhevXqxejIAAHXRssKiXG8CskR2tpGfXWRnG/nZRXa2kZ9dS5YscZZRNASAHGMlNLu5TVqlE/kZRHa2kZ9dZGcb+dlFdraRn13xeNyNGjWK1ZMBAAAAAAAA1B4UDQEAAAAAAAAkoGgIAECWmJDaLrKzjfzsIjvbyM8usrON/OwqLCx0lsWCIAhyvREAUBfNmzfPNW3a1P1+8SmupLhBrjcHAAAAAOqMtpfc7Ory99C5c+e6Jk2aVHpfOg0BIMf4zY3d3P5r0Ij8DCI728jPLrKzjfzsIjvbyM+uIAh8gc5yrx5FQwDIMVZCs0m5TW3ZnvwMIjvbyM8usrON/OwiO9vIz654PO7GjBnD6skAAAAAAAAAag+KhgAAAAAAAAASUDQEgJyzO8dF3Ra4esuWkJ9JZGcb+dlFdraRn11kZxv5WVZcXOwsK8r1BgBAXVdgeGLcup5bu2njcr0ZyALZ2UZ+dpGdbeRnF9nZRn52FRYWup49ezrL6DQEgBwLXCzXm4Asc5vfqCn5GUR2tpGfXWRnG/nZRXa2kZ9d8XjczZw5k4VQgNpu4MCB7sQTT8z1ZiCP3XPPPW7PPffM6rFBjH8AWKTcZjZblfwMIjvbyM8usrON/OwiO9vIz64gCNyECRP8T6soGiKlo48+2sViMX+pV6+eW3311d15553nFi1alHC/8D5fffVVwvWLFy92LVu29Ld9/PHHZdd/8sknbrvttnMtWrRwjRo1ct26dXNHHXWUW7JEczTkpylTprhbb73VXXzxxWaOz9ChQ30btOZP6NWrl3vzzTcrvb+2IdzW6EX7ns5jCgoKXNOmTd3666/vj8PkyZMT7jt48OCy+xYVFblOnTq5/v37uwULFqS9T59//rnr3bu3P24NGzb0+3fzzTcn3Ofqq692G2+8sSspKXGrrLKK22effdyoUaMqfd7otumi/dhyyy19FlEvvfSS22yzzfztev611lrLnXXWWWW3H3vssW748OHus88+S3ufAAAAAADIVxQNUaFddtnFF3/GjBnjizP33nuvGzRoULn7dejQwT388MPlCiwrrbRSwnW//vqrf86NNtrIffrpp27kyJHu9ttvd/Xr13elpaVZb2dNFxwfeOABt8UWW7iOHTuaOD5ffPGFO+SQQ9xxxx3nRowY4Qtnuvz8889VPlYFNu1TeFHhLZ3HTJo0yX377bfu/PPPd++//75be+21/fZHqcim5xw3bpy79tpr3X333efOPvvstPercePG7rTTTvPH5rfffnOXXHKJv+h5Qir09evXzxdp33vvPbd06VK30047uX///bfS5w63TZcvv/zSF2v32GMPN3fuXH/7Bx984Pr27ev2339/980337jvv//eXXnllf75Q8rp0EMPdbfddlva+wQAAAAAQL6iaIgKNWjQwLVu3doXvVR02mGHHXwhJpk64Z555hn333//lV330EMP+euj3n33Xf981113nS8qdenSxRfJ7r//ft85Jo888ohr1qyZe/nll33hRp1yO++8s2/pjXaGrbfeer6Ypw6/cDWi8ePHu7333tsX45o0aeIOOuggN3Xq1HKPU3FP+6ROPt0nLAxVRPuWathpLo5POtQVqcede+65bo011nCXX36522CDDdwdd9xR5WNVJNQ2hBd1EKb7mO7du7uDDz7YDRs2zLVq1cqdcsopCfdTh6Hu1759e1+AO+yww9yrr76a9n6pi1HFUBX41Kl4+OGH+3Mj2tn39ttv+y5Q3Wfdddf155POCxX5KhNumy5rrrmmGzJkiO+C/OOPP/ztr732mu9y1DHt0aOH31dlfueddyY8j84T7VM06/TYbVev2wJXvFgFafKzh+xsIz+7yM428rOL7GwjP8tKSkqcZRQNkRZ1qamDTd1UyTbccENfxHnhhRf8n1WkUTfYEUcckXA/FWTUyaXbKrNw4ULfxfXYY4/5AtScOXN8MSrqr7/+8q/34osvuh9++MFPLKqC4axZs3y3mYp36gBUcSr5cc8995wvAqnApE68U089tcJt0fOpA1Ddf/lyfKqiTjkVMKNUXNP1VVFRtU2bNm7HHXf0xz4bKnCefPLJ/vHTpk2r9H7L0yWq7HTMt9566wrvExaENdw7XRo6rs5QFa9VIAyz+eWXX6rs1tR5smzZMvf1119X+Nzz5s1LuAirJ9uk3FrP/If8DCI728jPLrKzjfzsIjvbyM/26sldunTxP62iaIgKvf76675rL5wXTwUgdVqlovnc1D0n6u7abbfdfLdZ1IEHHug7xVTkUWFq33339d1vYeEkpCGfun7zzTf3BbdHH33UF4c0LDSkYpOKiuo+W2eddfzwUQ2Hfeqpp/xjNt10U3+7CogaNhvSnIO6XsWxrbbayg//VRdgRXP3qcCnSUvbtm2bN8enKtqXVVddNeE6/bmy+Qn1elrIQ4VNXdQ9uc022/g5+rIRLiuvocipqPNPWWn+xkypU1FdnirQaSjy8ccfn/J+KiRrzkF1CKpzszI6d5SlLipm3nDDDe7pp5/2Haty+umn+7kSlbMKwCpiK08VAaPUvao5D//++++Ur6M5F3V7eNFxFlZCs0m5zSlpSX4GkZ1t5GcX2dlGfnaRnW3kZ1c8Hvffw1k9GbXStttu67v41DWlobTHHHOMn9MtFQ0VVSebuvtUFFORLJmq6+rgmjhxoh+C265dO3fVVVeVzScXHSqqAk20AKWuL81jF9L8gtGim25TASYswoiGmSY/brXVVvOvG1JhUm/gihbLCIeZhkOg8+H41AR11J100km+4Kr5G1UQ08/khUbSFa4OpYVFkgtzKsptsskm/tinM2Q6mYYjf/fdd77Iecstt/jiXioqKKozUEXhdPZfWeqigqaGVquIq9cJ51N84403fKeq5lHUfmg+Ru2HOmOjtH/J14UuvPBC3/0YXsJh96yEZpNy8/+AIz9zyM428rOL7GwjP7vIzjbysysIAl80ZPVk1EoqlHTt2tXPDacikopjDz74YMr7akVbLRyhxTfUzbfrrrtW+LwqhmlorgpGGvKp+6sAlOm2rQgrr7yy/zl79mwzx0dDaaNzOYr+rOszoYKYimTZCAu16spLLszpNhVjNfdfckdkOjSPpTr+TjjhBL8Cs+aqTKYFU9QJ+tFHH/nOxKpoWLmy1EXdq9dcc43PQUXJKLWWq7NR82mqC1ND15999tlyQ9qTu0hD6pBU92L0AgAAAABAPqJoiLRoQYyLLrrId1lVtMiDuuc+/vhjd+SRR6Y9Zr958+Z+aGx0dVvNCRd2eIm6ADWvoRb1qIhuU9dWdMEUFXT0OHUcRocba6XfkFbZ1b6Fc9clU5FIhR09V74cn6qog0/DtaM0x6Ouz4QKfHrtTGn/taKxhn9Hi2dhYU6FxFRzP2ZDXaLRIcL6DY4Khlqd+sMPP/QFxmwpo8oWNNF+aDhyNJvRo0f7Iq8KjwAAAAAAWFaU6w2AHRquqTn7tGLsOeecU+52rdg7ffr0CruntGqxClGaq0/FuHB+QXXTaW7BUL169fwccrfddpsfqqwi0GabbeY73yqihT/UfaYVedUdpsKjFjjR/IDRRUw0zFhDiTVnneYKPOOMM/wKyhV14akYqOf+/PPP/Wq5+XB8qnLmmWf6/b7xxhvd7rvv7ofnqgirQl50mOw///zjn190zFRg01Bova466VR004rOVdFcjnrM/Pnz/dBeDa2eMWOGX6SmOum4anh5OF+iFoxRjsowOiRZcyW+8sorfpWqcB5HzR9Y2QrUOl/C+2o/1D2oQvH555/vr1M3o4Ycay5KDY1XMVrnp+bf1KIx0aHTnTt39vllxHC7ep0WBG6lhXPJzyKys4387CI728jPLrKzjfzMisViflHO6LRd1tBpiLSFBTwVhVJ1vumNoOG8FXWRqei3YMECv7KuilMqbKnT7+WXX05YAVfdWyrWHHrooX4RC80flzwENNVrq1Ckzjx1uKnQp+JN8uPU6bbffvv54s9OO+3kF1G56667Kn1uDUdV4a2qyUtX1PHR82hexIpoLkIVzlQk1NDp559/3j9HdDEQzZGorsvowjKao0+FV73Wjz/+6N5//323/fbbu6qoS1MLxWg+RA3r1bHXXILRDs90qHMv1VDjkI6/ip1axEaFYBURr732WjdkyJCy+9x9991+rkAt4qIuyfBS1fmjwmx4Xz2/VtjWc6krVHRMNB+l/qyipYaXq8ioomq0S1XzK2rYdKYKHP8AsEi5rTxnKvkZRHa2kZ9dZGcb+dlFdraRn10FBQW+8UU/rYoFlmdkRK2jYphWvFUnV3VTQUrFM3XzZUJvEa3GrPnztLpxLo0dO9Z1797dd8F169bN1Rbq4tO8j2+99ZYv+FmkwqNWg/7jjz98Z2M61O2q+/568amuaXH1DNnGihN3MTer2SquxZxp/CPOGLKzjfzsIjvbyM8usrON/GpO20uyW/gzXWp80UKnmmc/nwqH4fdQNdxUNc9+/mw1kKfU2aeuPQ1hzbU333zTnXjiibWqYChasEQFN6sFw7B7U8O90y0YJjDcrl6nxWJuQaOm5GcR2dlGfnaRnW3kZxfZ2UZ+ZgVB4BfKtNyrx5yGQBo0ZFWXXNOcfbWR5l7UxTINywYAAAAAoLag0xB55eijj66Rocnh8ORMhyYDAAAAAADURRQNASDHYobb1et6bs3mzyQ/g8jONvKzi+xsIz+7yM428rM91Vnr1q1Nr57M8GQAyLEYExqbzU3/gIM9ZGcb+dlFdraRn11kZxv52VVQUOCLhpbRaQgAORY3/Junup7blJbtyM8gsrON/OwiO9vIzy6ys4387CotLXWjR4/2P62iaAgAOcc/AGyKuUUNGpOfSWRnG/nZRXa2kZ9dZGcb+Vk2f/58ZxlFQwAAAAAAAAAJKBoCAAAAAAAASEDREAByjJXQ7ObWcs5U8jOI7GwjP7vIzjbys4vsbCM/u2KxmOvQoQOrJwMAssfqyXZzK1k4N9ebgSyQnW3kZxfZ2UZ+dpGdbeRne/Xkli1bOsvoNASAHGMlNLu5/bNKJ/IziOxsIz+7yM428rOL7GwjP7tKS0vd77//zurJAIDlwT8AbIq5pUX1yc8ksrON/OwiO9vIzy6ys438LFu0aJGzjKIhAAAAAAAAgAQUDQEAAAAAAAAkoGgIADkWC+K53gRkmduqMyeSn0FkZxv52UV2tpGfXWRnG/nZXgilc+fO/qdVrJ4MADnG7CR2c2u4eGGuNwNZIDvbyM8usrON/OwiO9vIz65YLOaaNGniLLNb7gSAWiIe46PYam5/t+lKfgaRnW3kZxfZ2UZ+dpGdbeRnV2lpqRs5ciSrJwMAUBcF/OPNLLKzjfzsIjvbyM8usrON/OwqNVwwFM48AAAAAAAAAAkoGgIAAAAAAABIQNEQAHKMldDs5tZ22jjyM4jsbCM/u8jONvKzi+xsIz+7CgoKXI8ePUyvnmx3ywEAyLGi0mW53gRkiexsIz+7yM428rOL7GwjP7vq16/vLKNoCAA5xsTGdnMb36Yr+RlEdraRn11kZxv52UV2tpGfXfF43K+erJ9WFeV6AwCgrms94HLXvHnzXG8GslgJbcbIka5NrxNdYWFhrjcHGSA728jPLrKzjfzsIjvbyA+5RKkaAAAAAAAAQAKKhgAAAAAAAAASxIIgCBKvAgCsCPPmzXNNmzZ1c+bM8T9hi/761PwkWg0tFovlenOQAbKzjfzsIjvbyM8usrON/OwK8jS78Hvo3LlzXZMmTSq9L52GAABkacmSJbneBGSJ7GwjP7vIzjbys4vsbCM/u5YYz46iIQDkmOXVtOp6bqNGjSI/g8jONvKzi+xsIz+7yM428rMrXguyo2gIAAAAAAAAIAFFQwAAAAAAAAAJKBoCAJClwsLCXG8CskR2tpGfXWRnG/nZRXa2kZ9dhcazY/VkADCwahUAAAAAAMuL1ZMBwBB+d2M3N/2FS372kJ1t5GcX2dlGfnaRnW3kZ1dQC7KjaAgAOWZ5Na26ntuYMWPIzyCys4387CI728jPLrKzjfzsiteC7CgaAgAAAAAAAEhA0RAAAAAAAABAAoqGAABkqbi4ONebgCyRnW3kZxfZ2UZ+dpGdbeRnV7Hx7Fg9GQByvGrV369c65o0tv2XCQAAAADko2bbn5HrTcgrrJ4MAIbwqxu7uc0tbUB+BpGdbeRnF9nZRn52kZ1t5GdXPB53M2fOZCEUAED2+Pvfbm5TlzYmP4PIzjbys4vsbCM/u8jONvKzKwgCN2HCBP/TKoqGAAAAAAAAABJQNAQAAAAAAACQgKIhAABZalSwNNebgCyRnW3kZxfZ2UZ+dpGdbeRnV0lJibOsKNcbAAB1XUEs11uAbHNrX39+rjcDWSA728jPLrKzjfzsIjvbyM+uwsJC16VLF2cZnYYAkGOG58V1dT23Gcsakp9BZGcb+dlFdraRn11kZxv52RWPx92UKVNYPRkAkD3+/reb2yz9Ay7XG4KMkZ1t5GcX2dlGfnaRnW3kZ1cQBL5oyOrJAAAAAAAAAGoNioYAAAAAAAAAElA0BAAgS00KF+d6E5AlsrON/OwiO9vIzy6ys438bIrFYq5Fixb+p1WsngwAOcbqyXZza13v31xvBrJAdraRn11kZxv52UV2tpGfXQUFBW611VZzltFpCAA5Frc7L66r67lNWdqY/AwiO9vIzy6ys4387CI728jPrng87saPH8/qyQAA1EXzShvkehOQJbKzjfzsIjvbyM8usrON/GwKgsDNmjWL1ZMBAAAAAAAA1B4UDQEAAAAAAAAkoGgIADnGOih2c2tR9B/5GUR2tpGfXWRnG/nZRXa2kZ9dsVjMtW7dmtWTAQDZM/x3iKvrua1c9F+uNwNZIDvbyM8usrON/OwiO9vIz/bqya1bt3aW0WkIADnGSmh2c5u4pIT8DCI728jPLrKzjfzsIjvbyM+u0tJSN3r0aP/TKoqGAABkaWG8Xq43AVkiO9vIzy6ys4387CI728jPrvnz5zvLKBoCAAAAAAAASEDREAAAAAAAAEACioYAkGOsg2I3t1Xr/Ut+BpGdbeRnF9nZRn52kZ1t5GdXLBZzHTp0YPVkAED2DP8d4up6bk0LF+d6M5AFsrON/OwiO9vIzy6ys438bK+e3LJlS2cZnYYAkGOshGY3t3GLm5KfQWRnG/nZRXa2kZ9dZGcb+dlVWlrqfv/9d1ZPrmmPPPKIa9asWUaPOfroo90+++xTY9tk2YMPPuh22mknV9fdc889bs8990zrvjNnznSrrLKKGzduXI1vF2xasmSJ69Spk/vuu+9yvSlYgZYEhbneBGSJ7GwjP7vIzjbys4vsbCM/uxYtWuQsy2nRsKLC3scff+zHfM+ZM8f/uW/fvu6PP/5YIcVJva4uhYWFrnnz5m7TTTd1Q4YMcXPnznWWVHRsdcIOHDjQDRo0qOy6wYMHJ+y3xtyfeOKJbtasWQmPVUFE93nmmWfKPe9aa63lb9MxDP34449ur7328sW24uJi/3hlOW3aNJcPjj32WDd8+HD32WefVXnfK6+80u29995+H0TFw/CY6dKiRQu39dZbl3uu8Njusssu5Z7z+uuv97dts802ZdctXLjQXXjhha5Lly7+mLVq1co/7yuvvJLRvim7ww47zDVp0sQX3I877ji3YMGCCu+fvD/Ry9ChQyt8nLY9vF+DBg1cu3btfCH2xRdfLHff6HM2bdrU9e7d23344YcZ7ddJJ53kj03Dhg39sVEm+s1N9Jw75JBD/Dms+6yxxhru1ltvrfJ5o9tWVFTkVlttNTdgwAC3ePH/HwYwffp0d8opp/jbtK+tW7d2O++8sxs2bJi/vX79+u6cc85x559/fkb7BAAAAABAPjLRaagv/yo8rQgqskyePNlNnDjRffHFF7549thjj7n11lvPTZo0qdIuIwuef/55v48q2CQX/bTf48ePdw8//LB7++23fYEkmYoxuj3qq6++clOmTHGNGzdOKLBsv/32vpj2zjvvuN9++80/rm3btu7ff//NevvV1huPx111UJHn0EMPdbfddlul91MhT92ZKrwle//99/1x+/TTT/2+7bHHHm7q1KkJ92nTpo376KOP/DkV9dBDD/kCVNTJJ5/sC2633367L4YphwMOOMB3OmZCBcNffvnFvffee+7111/326dzuSLKVfsRvVx22WVupZVWcrvuumulr3XCCSf4+48ePdq98MILbs0113QHH3xwytfTOaD7qtC28sor++M1ZsyYtPdrww039M+h80nnVRAEvms2bPf+/vvv/WfFE0884ff/4osv9kXYO+64o8rnDrdt7Nix7q677nKPP/64u+KKK8pu33///d2IESPco48+6n+J8eqrr/qiaTQbHffPP//cvzYAAAAAAJaZHZ6sL/MqDpSUlLjjjz/eXXDBBb6wl+yGG27wRRtNPtmvXz+3dOnSSl9LnUbqINJj1KWkQpGKh+rSOu+888rup2LBaaed5s466yxf/FDHkXzyySduk0028Z1Ieg5t17Jly8o9Thd1W+mx6vxT8SM0e/Zsd+SRR/pOx0aNGvmizZ9//pnQvZa8r7fccktZF5xuV2FD3Wlh95S6N0VdgqmG5Kq7SvutTrEddtjBHXjggb7glExFEe3jhAkTEopful7PEVJRSN2ZDzzwgFt//fXd6quv7rbddlt38803+/+PdpS+8cYbbp111vGddZtttpn7+eefy2WvAo2KUTquKmxWdYzCx7388suuW7du/rmVUXS7RcdCz/3ff/9VeE68+eab/nW1bcl0Xum4rb322u6iiy5y8+bNc19//XXCfXSeqrClTEI6p2bMmOF23333hPtqW/Q8u+22m89TRbLTTz/dd0WmSwU1FRt17NUp26dPH1+EVPYVFb7VYar9iF5eeukld9BBB/nCYWV0/HX/9u3b+2N07bXXunvvvdfdf//9vqgapUzC43X33Xf7457qPKuICpFbbbWVPzYbbLCB/xxQpuGwcR0ndRaqO7Nz587u8MMPd8ccc0zKzsdk4bapgKpiproY1Ykq6npWF6n2Tedxx44d/ftcBUl104Z0Pqogn6obtzKsg2KTcmtXbz75GUR2tpGfXWRnG/nZRXa2kZ/thVA6d+7sf1plcsuffPJJP1xUX+DVWaRuLRUgkqm7S91P+qmCjQpJ0eGz6VLRR0UxFXSiE1jqOdWtpgKZ5sf7559/fLFn44039sMktU3qUIt2K4WPU4Htm2++8QWOm266yRd4okOLNS+aXu/LL7/0BUU9b1UFz5CGSKrYoyGxYdfYFlts4W9TF9RGG21U6eNVgFEXl/Yt2aqrruqLb2EBTF14zz77bLmiloovKpaq8BQtiKZy7rnnuhtvvNF9++23fsipCnnRfdVrKGsdI3VwKY90jpEep/NEnaLKSIUfdcBF6VhoO5MLfVEqFql4VxkVv/Q6kuq46fhEz72w0Jp8Xx03FSnnz5/vsqXjoQJYNGcVgvVBVdl+Rul99cMPP6TsrkzHUUcd5QtolRXr1EG8PF266lhVd6CK0Cr0VUTFa3W8ZkKdhBo6raKrqHCqi4rQ0SHLqaiYWNGQdz1WheXoRVg92Sbl1rhwKfkZRHa2kZ9dZGcb+dlFdraRn12xWMyP9NRPq3JeNNTQyfALeXipajikuqZUzFAHUffu3d2ll17qevXqVe5+KlpoWGLPnj1955C6uj744IOstlPPoUJOdCiiOtiuu+4616NHD3/RkEYVL8LX1JyCGuKpglh0SK3uo447PUaFI3WS6c+ibjkVwlQg23LLLd26667ri6QqSKpgkQ4dQxVkwnnXdFFxSkUzFVA0jDbZyJEjyx6nIoyKcxXNzRYWwFSo03BnzTGX3PmojjN1zGn4r7oplanm8EseuiuaX3HHHXf0GaoYqfuo2BhSIVDHVoVPHTMdi3SOkR6nLDbffHNf9NNzq8NPxdpol5w6Pv/+++8Kj6duS3XMRNuk46ah2epq1etoWHYynX8qEGmYsIpdzz33XMruwfvuu89vozoYVXzu379/2Zx56dJQ8eTh/CpSq3Cm29KhYrc6bcNic6ZUoNR7s6KFY1TQveSSS3yHo7oCM6FzIfyseOutt3ynYqpCrehYqqhd2dDskOZC1HOqK1XnmYbsq5MwPH4653UOqSCrbkKd3z/99FO559G5UtH5dPXVV/vzLbyExU5WQrNJuf21uDn5GUR2tpGfXWRnG/nZRXa2kZ9dpaWlvtbC6snLQUP91NEUvUS77lIZNWqU7+aJSv6z6Eu/ihIhDRfOdhGOsFsuWiFO7j7TsFAVqKL3UXFBQ5uj89mpoBa9jx6jYqFOJD2HChRhh5OogKQihm5bHuEQXBVFkun5dezV7adioboJVcxMRcVX7ZMKYOqYq2jorLr8VKRSF6ay0E8VU/WmidL+h1TYSt5XFYQ0fDmU7jHSfVR4C+m1VfBJPo4qlKqIVdlxS3XMRAUpzXOnufy6du3qC0v16tUrdz9dp6Gy6ozTwiIqqEX3KaSht5rjT8VtzWWo4q0Ko5dffrlbUbS/Tz31VNZdhtH3TPJvVMLCnKYV0DFTcTLVcaiMCu065homr+OortpUK1JpmLuGGKsonc5q4Src6z2gLmH9MkPdhkcccUTCnIYa3q2Ctbp4NbxeQ6STu5crO59UhFThPrwkD5eHPfHA7m8N6zqys4387CI728jPLrKzjfzsKjVcMMyLoqE6tFRsiV40r151SC7eqICR7SIaKjSprVTFqVB04Y8VSV1cyUN+0xm6rG3XMdB8gMlUmNOx11xz11xzjS+2qksyFRXjVExRMUbDXVXEqew1NT+iuvB0DNWFpf/PhIowNdnOq5WGNSy6IuqUTHXMRJ1i6jjdd9993VVXXeV/VjR8VcVVFQzvvPPOSuco1HmrQqGKt++++65fvVtFw3SH8aqzNLk4riHY2k/dVhV1j6ropTkjl+eDUYXwcP7K5MKcism6aBhzptShp2OuAqu2VQvGRDtT5ddff/Udn+owVEdjOnRs9B5Q8VmFcZ3/Kgr/9ddfZfdR8VhdsZqHVF2MGiYfXYm8qvNJ3b/6HIleAAAAAADIRzkvGmZDX+rVEReV/OfqpAKMOq803LiyCSw1nDOcXy+koaXqqtIiEaHkeeW0+rCKICrU6TmS59jTkGh1V2ohEFFBQgWX6OuoEJNcBEyuaOs6PYcKKlVRoUXFvYoWzlDRS51e6uTSMPB06PU1lDl59WTtf0jFOXV46ThUJJ1jJLqP5j0M6XYN0Y4+t+a8VJeaFmupiG5L55ipM1AFVQ2fTUXdlrqoA07DttOlfdK+pOqmS0Wdm9pPzUsY0vx8KphHuzMrou4/Le5RWSG1KhrGqyzVnZeqMLc8zx2l94Au0UKtujPVwayCpLpdsxV2KVe2SI6yST6flW9l5xMAAAAAABaYLBpq2KwKGypMqJtJC41obrHq6EZTAUIFOS0eos44Db/VvG7qblIHXmVOPfVUP9xQ26fuJ61erC6kAQMGJBQbtfqvrlMR6+mnn/ZzNJ555pn+NhUPVYg74YQT/KIlGiqpYa3qvtT14QrM06dP9/MpquilzjXN7Ral1WV1TPQaWqU37ETUsGM9bzqFJw0bVfdcKiq86Xk13DYVDe/UdofDPLUdKkJqkY9wP0LqpNNwXBVb1Lmlzj4VaCuSzjEKO/aUhYqLKqDpuTU0PDqUXQtWaDUjFTMromOmQlRF3YYhnX9nnHGGP08qGp6q4p3OreTVwEPKVisPa3s1H6COl+bOUxEs3a40ZaPhszo+mr9RhWut1q1FYMK5GTX/o4ZrR+d3FHXVadi5ViRPl/ZV7xkNwVcBWB2SJ598sjvllFP8dlcXDdvWnIA6NnoPqdNPXazqRNUiOKJzSK+p4ch6j4UdjXq/VEWFVt1XhXIVxHVeavizjqeK0tttt5174okn/Ptq7NixvmtU78Hk81nnVDrDoaMYbGCTcutYfy75GUR2tpGfXWRnG/nZRXa2kZ9dBQUFvumN1ZNXMA2H1dxgWiVYc4rpC7wKQhXNO5cJLVahuQ9VgFLhTAUcdSxpDjVdXxk9RkUeFWK0OIcKJ5oXLnl4pIZ9qntJxat+/fr5gmF0oQYV4jRfohbP0DaokKnnDYdbq4ihbjYVC/U6ej0diygVjHRyagVddXWFi2loe/Rcmk+tKlqEQ/NLVjTvmoYehyvgpurA0iIjZ599tl8kRcU6Lf6h54vOEycqsukYaJ9VtHnttdcqXNgi3WMken0VsNTVp7klNZeehptGqWirY1UZLdCi80zbXxWdK+ECLKloSHtFBUMJV6ZW0Uk5q+ip66KvPXjwYF8UrowWhlFRUEN0VVDr06ePX2QlpG1UITe5uKkiubpiMyl63X///f69ocLrfvvt57sydZwr6risiOYGrKzwr/e3CnLaH3Ur9u3b13fxqngYLvyi4coqEKq4p20KL9G5LSuihZV0X+2/5l5UV6iK8eoe1bmjLk0Nr9awaA3j1xBlnTvRrNVprPeWuk5RN9SL2Z6jpC4jO9vIzy6ys4387CI728jPrvpV1DbyXSxInhzPKM0zpqGPjz/+uMtn6iRTEe2WW27J2TaoO0tFsHBl2FzRQhLqClMHX2WFtGyoAHXWWWf57rGKqHtQ3WPqhFQnaWXeeOMNd+655/pOtlz/lkCFSRXXkhfgsE5duerw03lhlQqZKuSrOzTdX1Lo3Bv78rWu2UrL/0sP5GIluxaua4NZroBf/ZpCdraRn11kZxv52UV2tpHf8mu2/Rk5XT25V69eCYv05lr4PVQNL1WNaCxyBqk7SivxqgNLB17dYu+//7577733cr1pJlx//fW+m6+u0zDhxx57rMqCoWhhDA2F17BeLX6SK6rxq6iWzhBza9TVV1GHpgVaqEZ/GahDFwAAAAAA60wWDdVlpaGoWuRAi0NoGO4LL7zgdthhh1xvmgka2qphr3VdpueLOhfz4dz/+++/XW2UPL+ixbbzdFdqBgAAAAAg35ksGmoePXUWWmR56GVNDNWuqdHxmuNSFwAAAAAAANSRhVAAoDZhahK7uWluGfKzh+xsIz+7yM428rOL7GwjP7sKCgr8FFa5XhdhedjdcgAAcmxpkD8TGiMzZGcb+dlFdraRn11kZxv5OdNz31tG0RAAcqxWLGFfR3P7e0lT8jOI7GwjP7vIzjbys4vsbCM/u+LxuBs1apT/aRVFQwAAAAAAAAAJKBoCAAAAAAAASEDREACALBXEGChiFdnZRn52kZ1t5GcX2dlGfnYVFtqej7Io1xsAAHVdAUuhmc2ta4PZud4MZIHsbCM/u8jONvKzi+xsIz/bBcNevXo5y+g0BIAcC/jFodnc/i2tR34GkZ1t5GcX2dlGfnaRnW3kZ1cQBG7evHn+p1UUDQEgx+z+FVK3Kbd/lpaQn0FkZxv52UV2tpGfXWRnG/nZFY/H3ZgxY1g9GQAAAAAAAEDtQdEQAAAAAAAAQAKKhgAAZKl+rDTXm4AskZ1t5GcX2dlGfnaRnW3kZ1dxcbGzjNWTASDHWD3Zbm6dGszN9WYgC2RnG/nZRXa2kZ9dZGcb+dlePblnz57OMjoNASDHDC+m5ep6bnNLG5CfQWRnG/nZRXa2kZ9dZGcb+dkVj8fdzJkzWQgFAJA9/v63m9vUpY3JzyCys4387CI728jPLrKzjfzsCoLATZgwwf+0iqIhAAAAAAAAgAQUDQEAAAAAAAAkoGgIAECWGhUszfUmIEtkZxv52UV2tpGfXWRnG/nZVVJS4ixj9WQAyDFWT7abW/v683O9GcgC2dlGfnaRnW3kZxfZ2UZ+tldP7tKli7OMTkMAyDHD8+K6up7bjGUNyc8gsrON/OwiO9vIzy6ys4387IrH427KlCmsngwAyB5//9vNbZb+AZfrDUHGyM428rOL7GwjP7vIzjbysysIAl80tLx6MsOTASDHmm51gmvWvHmuNwMZKi0tdfVHjnRNe/XyQw9gB9nZRn52kZ1t5GcX2dlGfsglOg0BAAAAAAAAJKBoCAA5FouxEorV3Fq0aEF+BpGdbeRnF9nZRn52kZ1t5GdXrBZkFwssD64GAMPmzZvnmjZt6ubOneuaNGmS680BAAAAANRy8zL4HkqnIQDkmOXVtOp6buPHjyc/g8jONvKzi+xsIz+7yM428rMrXguyo2gIADlGw7fd3GbNmkV+BpGdbeRnF9nZRn52kZ1t5GdXUAuyo2gIAAAAAAAAIEFR4h8BACtK+BsnzSlRWFiY681BhkpLS92CBQvIzyCys4387CI728jPLrKzjfzsKs3T7LQ9kk4HJEVDAMiRmTNn+p+dOnXK9aYAAAAAAOqQ+fPn+wVRKkPREABypEWLFv6nJset6sMa+Ue/oevQoYObMGECq18bQ3a2kZ9dZGcb+dlFdraRn13z8jQ7dRiqYNi2bdsq70vREABypKDgf9PKqmCYT3+JIDPKjvxsIjvbyM8usrON/OwiO9vIz64meZhduk0rLIQCAAAAAAAAIAFFQwAAAAAAAAAJKBoCQI40aNDADRo0yP+EPeRnF9nZRn52kZ1t5GcX2dlGfnY1qAXZxYJ01lgGAAAAAAAAUGfQaQgAAAAAAAAgAUVDAAAAAAAAAAkoGgIAAAAAAABIQNEQAAAAAAAAQAKKhgBQg+68807XqVMnV1xc7DbddFP3zTffVHr/oUOHup49e/r79+rVy7355psrbFuxfPn98ssvbv/99/f3j8Vi7pZbblmh24rss7v//vvdlltu6Zo3b+4vO+ywQ5XvVeRPfi+++KLbaKONXLNmzVzjxo3deuut5x5//PEVur3I/u+90DPPPOM/O/fZZ58a30ZUT36PPPKIzyx60eNg4703Z84c169fP9emTRu/smv37t35d6eR/LbZZpty7z1ddt999xW6zcjuvafvCD169HANGzZ0HTp0cP3793eLFi1y+YqiIQDUkGeffdYNGDDADRo0yA0fPtytu+66buedd3bTpk1Lef8vvvjCHXLIIe64445zI0aM8F+cdPn5559X+LYj8/wWLlzoOnfu7K655hrXunXrFb69yD67jz/+2L/3PvroI/fll1/6f8DttNNO7p9//lnh247M82vRooW7+OKLfXY//fSTO+aYY/zlnXfeWeHbXtdlml1o3Lhx7pxzzvHFe9jKr0mTJm7y5Mlll7///nuFbjOyy27JkiVuxx139O+9559/3o0aNcr/Aq1du3YrfNuReX76ZVn0fafvCoWFhe7AAw9c4dte1z2bYXZPPfWUu+CCC/z9f/vtN/fggw/657joootc3goAADVik002Cfr161f259LS0qBt27bB1VdfnfL+Bx10ULD77rsnXLfpppsGJ510Uo1vK5Y/v6iOHTsGN998cw1vIWoiO1m2bFlQUlISPProozW4laip/GT99dcPLrnkkhraQlRndnq/bbHFFsEDDzwQHHXUUcHee++9grYWy5vfww8/HDRt2nQFbiGqK7u777476Ny5c7BkyZIVuJWoqb/39G9O/btlwYIFNbiVqI7sdN/tttsu4boBAwYEvXv3DvIVnYYAUAP0G9zvv//eD3MMFRQU+D+rGyYVXR+9v+g3VRXdH/mVH2pPduoaXbp0qe9gg638giBwH3zwge+a2WqrrWp4a1Ed2Q0ZMsStssoqvsse9vJbsGCB69ixo+/Q3nvvvf1UHcj/7F599VW3+eab++HJq666qlt77bXdVVdd5UpLS1fglqO6/t2ibrWDDz7YT9GB/M5uiy228I8JhzCPGTPGTwuw2267uXxVlOsNAIDaaMaMGf4fXvqHWJT+/Pvvv6d8zJQpU1LeX9cj//ND7cnu/PPPd23bti1XxEf+5jd37lw/rG7x4sV+iNZdd93lh94hv7P7/PPP/ZfdH374YQVtJaozP83J9dBDD7l11lnHvwdvuOEG/4VYhcP27duvoC1HNtmpUPHhhx+6ww47zBcs/vrrL3fqqaf6X5hp2CTs/LtFxScNT9ZnKfI/u0MPPdQ/rk+fPv4XncuWLXMnn3xyXg9PpmgIAADwfzQnpRZk0DyHTOhvR0lJiS88qetJnYaaX0hzjGqyeOSn+fPnuyOOOMLPo7byyivnenOQBXWq6RJSwXCNNdZw9957r7v88stzum2oXDwe9x2+9913n/9Fy4Ybbujn8b3++uspGhqjYqEWT9xkk01yvSlIg/59qa5e/XJTi6aoYH/mmWf6z8yBAwe6fETREABqgL4A6R9hU6dOTbhef65okQxdn8n9kV/5wX526pJR0fD999/3nTOwk5+GA3Xt2tX/v1ZP1uTiV199NUXDPM5u9OjRfhGGPffcM6GQIUVFRX6IeZcuXVbAlqO6/t6rV6+eW3/99f2XYOR3dloxWXnpcSEVfDW6RUMu69evX+PbjeV/7/3777/+F52a5gE2shs4cKD/hdnxxx/v/6yCr3I88cQT/aJu+vdMvsm/LQKAWkD/2NJvbdXxEv0ypD9Hfysfpeuj95f33nuvwvsjv/KD7eyuu+46/1vet99+22200UYraGtRU+89PUZDlZG/2fXs2dONHDnSd4iGl7322sttu+22/v81Rx5svfc0TE+ZqiCF/M6ud+/evrgbFurljz/+8NlRMLTz3hs6dKj/u+7www9fAVuK6shO82YnFwbD4r2GK+elXK/EAgC11TPPPBM0aNAgeOSRR4Jff/01OPHEE4NmzZoFU6ZM8bcfccQRwQUXXFB2/2HDhgVFRUXBDTfcEPz222/BoEGDgnr16gUjR47M4V7UXZnmt3jx4mDEiBH+0qZNm+Ccc87x///nn3/mcC/qpkyzu+aaa4L69esHzz//fDB58uSyy/z583O4F3VXpvldddVVwbvvvhuMHj3a31+fofosvf/++3O4F3VTptklY/VkW/lddtllwTvvvOPfe99//31w8MEHB8XFxcEvv/ySw72omzLNbvz48X613dNOOy0YNWpU8PrrrwerrLJKcMUVV+RwL+qubD87+/TpE/Tt2zcHW4xss9P3O733nn766WDMmDH+3y9dunQJDjrooCBfMTwZAGpI37593fTp092ll17qh3toyJy6mMLJcsePH5/wmybNBfTUU0+5Sy65xE+G261bN/fyyy/7Fe2Q//lNmjTJD8uKDnXVZeutt/bzlyB/s7v77rv9cKwDDjgg4Xk0r9PgwYNX+PbXdZnmp2E9msB/4sSJrmHDhr6D7YknnvDPg/zODrbzmz17tjvhhBP8fZs3b+47br744gu35ppr5nAv6qZMs1Mn7zvvvOP69+/vp+PQQlKaV00LgcHGZ6emcNBiUu+++26OthrZZKfvebFYzP/UPKKtWrXy03RceeWVLl/FVDnM9UYAAAAAAAAAyB/8qg8AAAAAAABAAoqGAAAAAAAAABJQNAQAAAAAAACQgKIhAAAAAAAAgAQUDQEAAAAAAAAkoGgIAAAAAAAAIAFFQwAAAAAAAAAJKBoCAAAAAAAASEDREAAAAAAAAEACioYAAAAAlsvRRx/tYrFYuctff/3l/l979xMSVRfGcfx5KZ3yLySkWEiipSWVgtZCzMzNCCYKmopUiwoCRcMQSiFRy4UZ2j9RHDIhoXChqIhtWgiGiyAlRIQsKcoYFzKSCzH05TkwQ7fXyPdVX5O+H7jM3DvnnHvnLn+c55zBwUE5ffq0hIaGmmvd3d2rGnN0dFQyMjJk9+7dsmPHDtm3b5/k5uaK0+nc8P8DAAAIDQEAAACsA7vdLtPT05YjPDxc5ufn5ejRo/Lw4cNVjzUzMyOpqamya9cuef78uYyPj0tbW5sJHnW8jbK4uLhhYwMAsNUQGgIAAABYM5vNJiEhIZZj27ZtkpaWJjdv3pSsrKxVjzU0NCQul0scDofExcWZ8DElJUUaGhrMd7exsTFJT0+XgIAA8ff3l6SkJJmcnDS/LS0tSXV1tezdu9c8W2xsrAwMDHj6Tk1NmZmPz549k+TkZDObsaOjw/ym9z148KC5Fh0dLU1NTev6rgAA2Aq2b/YDAAAAAMD3NHD89u2bdHV1SXZ2tgn3fvTp0yc5ceKEnDx5Ul68eGGCQw0btZ+6e/eu3LlzR1paWkzw+OjRI1PurEHj/v37PeNcu3bNtNM27uDwxo0b8uDBA3Pt9evXcunSJfH19ZXz58//r+8BAIDN9Nfy8vLypj4BAAAAgC2/puGTJ09M6OamMww7Ozst7TT80yAwMzPzl2NWVFRIXV2dCQOPHTsmp06dknPnzklwcLD5vby8XJ4+fSoTExPi5eX1j/579uyRwsJC085Nx0lISDCl0jrTUGctNjY2SklJiadNZGSk1NTUSH5+vueazpTs7++Xly9f/oe3AwDA1kR5MgAAAIA10/LhkZERz3Hv3r1V9autrRU/Pz/P8eHDB3P91q1b8uXLF2lubpaYmBjzqaXCb968Mb/rPbQceaXAcG5uTj5//iyJiYmW63qu6yN+Lz4+3vNd10vU8uYLFy5YnklDQ3fZMwAAfwrKkwEAAACsmZbv6iy9f+vy5cty5swZz7luduIWFBQkOTk55tBwUcuF6+vrpb29XXbu3Lluz+329etX89na2irHjx+3tNP1GQEA+JMQGgIAAADYNLpDsh6/4u3tLREREZ7dk48cOWLCQ93x+MfZhlrSrOGjrnGom5y46bmWKP+Mlj5rv3fv3klBQcGa/hcAAFsdoSEAAACADaOz996+fes5f//+vSkt1qAwLCxsxT59fX1mvcK8vDw5cOCA6DLsvb29Zl3BtrY206aoqEju379v2ly/fl0CAwNleHjYhIJRUVFSVlYmlZWVJmjUnZO1n97XvUPyz1RVVUlxcbEZz263y8LCgrx69UpmZ2eltLR0nd8OAAC/L0JDAAAAABtGAzdd79DNHbzpTsSPHz9esc+hQ4fEx8dHrl69Kh8/fhSbzWZ2PHY4HHL27FlP6bLumqzhoM4m1PJhDQfd6xhq8OdyucwYTqfTjNnT02PZOXklFy9eNPe+ffu2GVvLlw8fPixXrlxZx7cCAMDvj92TAQAAAAAAAFiwezIAAAAAAAAAC0JDAAAAAAAAABaEhgAAAAAAAAAsCA0BAAAAAAAAWBAaAgAAAAAAALAgNAQAAAAAAABgQWgIAAAAAAAAwILQEAAAAAAAAIAFoSEAAAAAAAAAC0JDAAAAAAAAABaEhgAAAAAAAADke38DlVKd4SefJawAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(12, 6))\n",
+    "sns.barplot(x='f1', y='name', data=results_df, palette='magma')\n",
+    "plt.title('Performance Comparison: F1-Score of All Experiments')\n",
+    "plt.xlabel('F1-Score')\n",
+    "plt.ylabel('Model Configuration')\n",
+    "plt.grid(axis='x', linestyle='--', alpha=0.6)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "383e0c37",
+   "metadata": {},
+   "source": [
+    "# Final Conclusion & Best Model\n",
+    "Based on the experiments above:\n",
+    "1.  **Best Performer:** The Large Batch(Adam) model achieved the highest F1-Score.\n",
+    "2.  **Optimizer:** {Adam} showed better convergence stability.\n",
+    "3.  **Next Steps:** The final model weights are saved in `models/best_cnn_model` for deployment and integration "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/models/best_cnn_model.py
+++ b/src/models/best_cnn_model.py
@@ -1,0 +1,86 @@
+import pickle
+import numpy as np
+import pandas as pd
+from pathlib import Path
+from keras.models import Sequential
+from keras.layers import Embedding, Conv1D, GlobalMaxPooling1D, Dense, Dropout, Input
+from keras.callbacks import EarlyStopping
+from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+FEATURES_DIR = BASE_DIR / "data" / "dl_features"
+MODELS_DIR = BASE_DIR / "models"
+MODELS_DIR.mkdir(parents=True, exist_ok=True) 
+
+
+def load_features():
+    print(f"Loading features from: {FEATURES_DIR}")
+    X_train = np.load(FEATURES_DIR / "X_train_pad.npy")
+    X_val = np.load(FEATURES_DIR / "X_val_pad.npy")
+    X_test = np.load(FEATURES_DIR / "X_test_pad.npy")
+    y_train = np.load(FEATURES_DIR / "y_train.npy")
+    y_val = np.load(FEATURES_DIR / "y_val.npy")
+    y_test = np.load(FEATURES_DIR / "y_test.npy")
+    with open(FEATURES_DIR / "meta.pkl", "rb") as f:
+        meta = pickle.load(f)
+    return X_train, X_val, X_test, y_train, y_val, y_test, meta
+
+def build_cnn_model(max_words, max_len, embedding_dim=50, dropout_rate=0.5, optimizer='adam'):
+    model = Sequential([
+        Input(shape=(max_len,)), 
+        Embedding(input_dim=max_words, output_dim=embedding_dim),
+        Conv1D(filters=128, kernel_size=5, activation='relu'),
+        GlobalMaxPooling1D(),
+        Dropout(dropout_rate),
+        Dense(1, activation='sigmoid')
+    ])
+    model.compile(optimizer=optimizer, loss='binary_crossentropy', metrics=['accuracy'])
+    return model
+
+def evaluate_model(model, X_test, y_test):
+    y_pred = (model.predict(X_test, verbose=0) > 0.5).astype(int)
+    return {
+        "accuracy": accuracy_score(y_test, y_pred),
+        "precision": precision_score(y_test, y_pred),
+        "recall": recall_score(y_test, y_pred),
+        "f1": f1_score(y_test, y_pred)
+    }
+
+
+if __name__ == "__main__":
+    X_train, X_val, X_test, y_train, y_val, y_test, meta = load_features()
+
+    BEST_CONFIG = {
+        "name": "Large Batch(Adam)",
+        "opt": "adam",
+        "dr": 0.5,
+        "bs": 64,
+        "epochs": 10
+    }
+
+    print(f"\nTraining the Best Model: {BEST_CONFIG['name']}...")
+
+    model = build_cnn_model(
+        max_words=meta["max_words"],
+        max_len=meta["max_len"],
+        dropout_rate=BEST_CONFIG["dr"],
+        optimizer=BEST_CONFIG["opt"]
+    )
+
+    early_stopping = EarlyStopping(monitor='val_loss', patience=2, restore_best_weights=True)
+    
+    model.fit(
+        X_train, y_train,
+        validation_data=(X_val, y_val),
+        epochs=BEST_CONFIG["epochs"],
+        batch_size=BEST_CONFIG["bs"],
+        callbacks=[early_stopping],
+        verbose=1
+    )
+
+    print("\nFinal Evaluation on Test Set:")
+    metrics = evaluate_model(model, X_test, y_test)
+    for key, value in metrics.items():
+        print(f"- {key.capitalize()}: {value:.4f}")
+
+    

--- a/src/models/cnn_baseline.py
+++ b/src/models/cnn_baseline.py
@@ -1,0 +1,63 @@
+import pickle
+from pathlib import Path
+import numpy as np
+from keras.models import Sequential
+from keras.layers import Embedding, Conv1D, GlobalMaxPooling1D, Dense, Dropout, Input
+from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score
+
+BASE_DIR = Path.cwd().parents[1]
+DATA_DIR = BASE_DIR / "data"
+FEATURES_DIR = DATA_DIR / "dl_features"
+print(BASE_DIR)
+print(DATA_DIR)
+print(FEATURES_DIR)
+
+
+# Functions
+
+def load_features():
+    """Load the preprocessed arrays and metadata."""
+    print("Loading data from:", FEATURES_DIR)
+    X_train_pad = np.load(FEATURES_DIR / "X_train_pad.npy")
+    X_val_pad = np.load(FEATURES_DIR / "X_val_pad.npy")
+    X_test_pad = np.load(FEATURES_DIR / "X_test_pad.npy")
+
+    y_train = np.load(FEATURES_DIR / "y_train.npy")
+    y_val = np.load(FEATURES_DIR / "y_val.npy")
+    y_test = np.load(FEATURES_DIR / "y_test.npy")
+
+    with open(FEATURES_DIR / "meta.pkl", "rb") as f:
+        meta = pickle.load(f)
+
+    return X_train_pad, X_val_pad, X_test_pad, y_train, y_val, y_test, meta
+
+def build_cnn_model(max_words, max_len, embedding_dim=50, dropout_rate=0.5, optimizer='adam'):
+    """
+    Build the 1D-CNN model. 
+    Notice: added dropout_rate and optimizer as arguments for tuning!
+    """
+    print(f"Building CNN model (Optimizer: {optimizer}, Dropout: {dropout_rate})....")
+    model = Sequential([
+        Input(shape=(max_len,)), 
+        Embedding(input_dim=max_words, output_dim=embedding_dim),
+        Conv1D(filters=128, kernel_size=5, activation='relu'),
+        GlobalMaxPooling1D(),
+        Dropout(dropout_rate),
+        Dense(1, activation='sigmoid')
+    ])
+
+    model.compile(optimizer=optimizer, loss='binary_crossentropy', metrics=['accuracy'])
+    return model
+
+def evaluate_model(model, X_test, y_test):
+    """Evaluate the model and return metrics as a dictionary."""
+    y_pred_probs = model.predict(X_test, verbose=0)
+    y_pred_labels = (y_pred_probs > 0.5).astype(int)
+    
+    metrics = {
+        "accuracy": accuracy_score(y_test, y_pred_labels),
+        "precision": precision_score(y_test, y_pred_labels),
+        "recall": recall_score(y_test, y_pred_labels),
+        "f1": f1_score(y_test, y_pred_labels)
+    }
+    return metrics


### PR DESCRIPTION
Optimizing a 1D-CNN model for text classification.
Key Contributions:
Hyperparameter Tuning: Conducted 6 experiments comparing different configurations:
    1-Optimizers: Evaluated `Adam` vs `RMSprop`.
    2-Dropout: Tested `0.5` and `0.7` to minimize overfitting.
    3-Batch Size: Compared `32` and `64` for training stability.
Results: The Large Batch (Adam) configuration achieved the best performance (Highest F1-Score).
saving the best model in best_cnn_model.py